### PR TITLE
Prepare workflows for trusted publishing

### DIFF
--- a/.github/workflows/build-package-pypi.yaml
+++ b/.github/workflows/build-package-pypi.yaml
@@ -13,6 +13,4 @@ jobs:
       enable_dev_dependencies: 0
       runner: ubuntu-latest
     secrets:
-      PYPI_USER: ${{ secrets.PYPI_USERNAME }}
-      PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       PYPI_HOST: pypi.org

--- a/.github/workflows/build-package-test-pypi.yaml
+++ b/.github/workflows/build-package-test-pypi.yaml
@@ -16,6 +16,4 @@ jobs:
       enable_dev_dependencies: 1
       runner: ubuntu-latest
     secrets:
-      PYPI_USER: ${{ secrets.TEST_PYPI_USERNAME }}
-      PYPI_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
       PYPI_HOST: test.pypi.org

--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Publish SDK package to pypi
         uses: pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70 # v1.12.3
-        if: ${{ secrets.PYPI_HOST == 'test.pypi.org' }}
+        if: ${{ PYPI_HOST == 'test.pypi.org' }}
         with:
           repository-url: https://test.pypi.org/
           verbose: true

--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -10,16 +10,10 @@ on:
         required: true
         type: string
     secrets:
-      PYPI_USER:
-        required: true
-      PYPI_PASSWORD:
-        required: true
       PYPI_HOST:
         required: true
 
 env:
-  PYPI_USER: ${{ secrets.PYPI_USER }}
-  PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
   PYPI_HOST: ${{ secrets.PYPI_HOST }}
   ENABLE_DEV_DEPENDENCIES: ${{ inputs.enable_dev_dependencies }}
 
@@ -71,13 +65,11 @@ jobs:
           path: dist
 
       - name: Publish SDK package to pypi
-        run: |
-          if [[ $PYPI_HOST = "test.pypi.org" ]]; then
-            twine upload -r testpypi dist/* -u $PYPI_USER -p $PYPI_PASSWORD
-          else
-            twine upload dist/* -u $PYPI_USER -p $PYPI_PASSWORD
-          fi
-
+        uses: pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70 # v1.12.3
+        if: ${{ secrets.PYPI_HOST == 'test.pypi.org' }}
+        with:
+          repository-url: https://test.pypi.org/
+          verbose: true
 
       - name: Clean up dist directory if it was created
         if: ${{ always() }}


### PR DESCRIPTION
That step is required by security team prior to the repo moving.
Pypi-related secrets were removed from the repo.