### PR TITLE
Use zizmor linter to check workflows

### DIFF
--- a/.github/workflows/bandit.yaml
+++ b/.github/workflows/bandit.yaml
@@ -28,7 +28,6 @@ jobs:
         env:
           CHANGED_FILES: ${{steps.files.outputs.all_changed_files}}
         run: |
-          CHANGED_FILES=""
           if [[ ! -z "$CHANGED_FILES" ]]; then
             pip install bandit
             echo "Bandit version: "$(bandit --version | head -1)

--- a/.github/workflows/bandit.yaml
+++ b/.github/workflows/bandit.yaml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - id: files
         uses: tj-actions/changed-files@dcc7a0cba800f454d79fff4b993e8c3555bcc0a8 # v45.0.7
         with:

--- a/.github/workflows/bandit.yaml
+++ b/.github/workflows/bandit.yaml
@@ -25,13 +25,15 @@ jobs:
           python-version: "3.12"
 
       - name: Run checks
+        env:
+          CHANGED_FILES: ${{steps.files.outputs.all_changed_files}}
         run: |
-          CHANGED_FILES="${{steps.files.outputs.all_changed_files}}"
-          if [[ ! -z $CHANGED_FILES ]]; then
+          CHANGED_FILES=""
+          if [[ ! -z "$CHANGED_FILES" ]]; then
             pip install bandit
             echo "Bandit version: "$(bandit --version | head -1)
-            echo "The files will be checked: "$(echo $CHANGED_FILES)
-            bandit -a file --ini tox.ini --verbose -r $CHANGED_FILES
+            echo "The files will be checked: "$(echo "$CHANGED_FILES")
+            bandit -a file --ini tox.ini --verbose -r "$CHANGED_FILES"
           else
             echo "No files with the \"py\" extension found"
           fi

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -9,11 +9,8 @@ on:
     paths-ignore:
       - ".github/**" # Ignore changes towards the .github directory
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+# No permissions by default
+permissions: {}
 
 # Allow one concurrent deployment
 concurrency:
@@ -26,6 +23,11 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
@@ -34,6 +36,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
@@ -77,7 +81,7 @@ jobs:
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           # Upload entire repository
-          path: '.'
+          path: "."
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -30,19 +30,20 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
+          persist-credentials: false
 
       - name: Set up QEMU [aarch64 only]
         if: matrix.cibw_archs == 'aarch64'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
         with:
           platforms: arm64
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.22.0
+        uses: pypa/cibuildwheel@d04cacbc9866d432033b1d09142936e6a0e2121a # v2.23.2
         env:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         with:
           name: geti-sdk-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
@@ -56,7 +57,9 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
@@ -77,7 +80,7 @@ jobs:
       - name: Check package contents
         run: twine check dist/*
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
         with:
           name: geti-sdk
           path: dist

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -10,5 +10,7 @@ jobs:
     steps:
       - name: "Checkout Repository"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: "Dependency Review"
         uses: actions/dependency-review-action@3b139cfc5fae8b618d3eae3675e383bb1769c019 # v4.5.0

--- a/.github/workflows/pre-merge-tests.yml
+++ b/.github/workflows/pre-merge-tests.yml
@@ -44,6 +44,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           lfs: true
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,8 +14,8 @@ on:
   push:
     branches: [ "main" ]
 
-# Declare default permissions as read only.
-permissions: read-all
+# No permissions by default
+permissions: {}
 
 jobs:
   analysis:

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
@@ -89,6 +91,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Run Trivy Scan (dockerfile and secrets)
         uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
@@ -124,6 +128,8 @@ jobs:
           egress-policy: audit
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Setup Python
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:

--- a/.github/workflows/zizmor-scan.yaml
+++ b/.github/workflows/zizmor-scan.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174 # v5.4.0
       - name: Run zizmor
-        run: uvx zizmor=="$ZIZMOR_VERSION" . --format sarif > results.sarif
+        run: uvx zizmor=="$ZIZMOR_VERSION" . --format sarif --config .github/zizmor.yaml > results.sarif
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0 # v3.28.8
         with:
@@ -60,4 +60,4 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174 # v5.4.0
       - name: Run zizmor
-        run: uvx zizmor=="$ZIZMOR_VERSION" . --min-confidence high --min-severity high
+        run: uvx zizmor=="$ZIZMOR_VERSION" . --min-confidence high --min-severity high --config .github/zizmor.yaml

--- a/.github/workflows/zizmor-scan.yaml
+++ b/.github/workflows/zizmor-scan.yaml
@@ -1,0 +1,63 @@
+name: "Workflows static analysis"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+  push:
+    branches:
+      - main
+      - "releases/**"
+  pull_request:
+    branches: ["*"]
+    paths:
+      - ".github/**"
+env:
+  ZIZMOR_VERSION: 1.5.2
+
+permissions: {}
+
+jobs:
+  zizmor-scan-full:
+    # Run on schedule, workflow_dispatch or push, all severity, publish results into Security tab (reporting)
+    # Skip Dependabot to avoid permission issues.
+    if:
+      ((github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.merged == true)
+      && github.actor != 'dependabot[bot]')
+    name: Check workflows with zizmor
+    permissions:
+      contents: read
+      security-events: write # to upload issues into security tab
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174 # v5.4.0
+      - name: Run zizmor
+        run: uvx zizmor=="$ZIZMOR_VERSION" . --format sarif > results.sarif
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@9e8d0789d4a0fa9ceb6b1738f7e269594bdd67f0 # v3.28.8
+        with:
+          sarif_file: results.sarif
+          category: zizmor
+
+  zizmor-scan-pr:
+    # Run only within Pull Requests, fail on high severity and high confidence
+    if: (github.event_name == 'pull_request')
+    name: Check PR with zizmor
+    permissions:
+      contents: read
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174 # v5.4.0
+      - name: Run zizmor
+        run: uvx zizmor=="$ZIZMOR_VERSION" . --min-confidence high --min-severity high

--- a/.github/zizmor.yaml
+++ b/.github/zizmor.yaml
@@ -1,0 +1,5 @@
+rules:
+  cache-poisoning:
+    ignore:
+      # this workflow does not generate artifacts, uv is used to execute zizmor
+      - zizmor-scan.yaml:3:1


### PR DESCRIPTION

This PR introduces [zizmor](https://github.com/woodruffw/zizmor) linter for GitHub actions workflows to prevent and detect potential issues in workflows:
- check PR into workflows, fail only if high severity issues is detected
- periodic scan (all severity), generates SARIF output and upload it into GitHub Security tab for future analysis
- false positives with justification can be added into `.github\zizmor.yaml`

Also, minor issues flagged by zizmor in the current workflows are fixed in this PR.
