### PR TITLE
Prepare workflows for trusted publishing

### DIFF
--- a/.github/workflows/build-package-pypi.yaml
+++ b/.github/workflows/build-package-pypi.yaml
@@ -13,6 +13,4 @@ jobs:
       enable_dev_dependencies: 0
       runner: ubuntu-latest
     secrets:
-      PYPI_USER: ${{ secrets.PYPI_USERNAME }}
-      PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       PYPI_HOST: pypi.org

--- a/.github/workflows/build-package-test-pypi.yaml
+++ b/.github/workflows/build-package-test-pypi.yaml
@@ -16,6 +16,4 @@ jobs:
       enable_dev_dependencies: 1
       runner: ubuntu-latest
     secrets:
-      PYPI_USER: ${{ secrets.TEST_PYPI_USERNAME }}
-      PYPI_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
       PYPI_HOST: test.pypi.org

--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Publish SDK package to pypi
         uses: pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70 # v1.12.3
-        if: ${{ secrets.PYPI_HOST == 'test.pypi.org' }}
+        if: ${{ PYPI_HOST == 'test.pypi.org' }}
         with:
           repository-url: https://test.pypi.org/
           verbose: true

--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -10,16 +10,10 @@ on:
         required: true
         type: string
     secrets:
-      PYPI_USER:
-        required: true
-      PYPI_PASSWORD:
-        required: true
       PYPI_HOST:
         required: true
 
 env:
-  PYPI_USER: ${{ secrets.PYPI_USER }}
-  PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
   PYPI_HOST: ${{ secrets.PYPI_HOST }}
   ENABLE_DEV_DEPENDENCIES: ${{ inputs.enable_dev_dependencies }}
 
@@ -71,13 +65,11 @@ jobs:
           path: dist
 
       - name: Publish SDK package to pypi
-        run: |
-          if [[ $PYPI_HOST = "test.pypi.org" ]]; then
-            twine upload -r testpypi dist/* -u $PYPI_USER -p $PYPI_PASSWORD
-          else
-            twine upload dist/* -u $PYPI_USER -p $PYPI_PASSWORD
-          fi
-
+        uses: pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70 # v1.12.3
+        if: ${{ secrets.PYPI_HOST == 'test.pypi.org' }}
+        with:
+          repository-url: https://test.pypi.org/
+          verbose: true
 
       - name: Clean up dist directory if it was created
         if: ${{ always() }}

--- a/.github/workflows/build-package.yaml
+++ b/.github/workflows/build-package.yaml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Publish SDK package to pypi
         uses: pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70 # v1.12.3
-        if: ${{ PYPI_HOST == 'test.pypi.org' }}
+        if: ${{ env.PYPI_HOST == 'test.pypi.org' }}
         with:
           repository-url: https://test.pypi.org/
           verbose: true


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/geti-sdk/blob/main/CONTRIBUTING.md -->

### Summary
Replaces https://github.com/open-edge-platform/geti-sdk/pull/574 as I can't push to the main repo anymore
<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have tested my changes manually.​
- [ ] I have added tests to cover my changes.​

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/geti-sdk/blob/main/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
# http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions
# and limitations under the License.
```
