### PR TITLE
Correct pytest-recording version

### DIFF
--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -1,7 +1,7 @@
 # Requirements for running the tests
 vcrpy==7.0.*
 pytest==8.3.*
-pytest-recording==0.12.*
+pytest-recording==0.13.2
 pytest-cov==6.0.*
 pytest-env==1.1.*
 pytest-html==4.1.*

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -1,7 +1,7 @@
 # Requirements for running the tests
 vcrpy==7.0.*
 pytest==8.3.*
-pytest-recording==0.13.*
+pytest-recording==0.12.*
 pytest-cov==6.0.*
 pytest-env==1.1.*
 pytest-html==4.1.*

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -1,10 +1,11 @@
 # Requirements for running the tests
 vcrpy==7.0.*
 pytest==8.3.*
-pytest-recording==0.13.2
+pytest-recording==0.13.2  # pinned due to https://github.com/kiwicom/pytest-recording/issues/174
 pytest-cov==6.0.*
 pytest-env==1.1.*
 pytest-html==4.1.*
+snowballstemmer==2.2.*  # pinned because pytest-recording subdeps are loose
 flake8==7.1.*
 pydocstyle>=6.1
 black>=24.1


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/geti-sdk/blob/main/CONTRIBUTING.md -->

### Summary

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

Corrected the `pytest-recording` version to 0.13.2 due to issues with `os.pathconf` not being present on Windows systems.
This error is caused by a regression in that package in 0.13.3: https://github.com/kiwicom/pytest-recording/issues/174

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

GHA

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have tested my changes manually.​
- [ ] I have added tests to cover my changes.​

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/geti-sdk/blob/main/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
# http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions
# and limitations under the License.
```
