### PR TITLE
Bugfix: unrecognized 'lifecycle_stage' key in model group response

### DIFF
--- a/geti_sdk/data_models/model_group.py
+++ b/geti_sdk/data_models/model_group.py
@@ -56,6 +56,7 @@ class ModelSummary:
     id: Optional[str] = attr.field(default=None, repr=False)
     model_storage_id: Optional[str] = attr.field(default=None, repr=False)
     label_schema_in_sync: Optional[bool] = attr.field(default=None)  # Added in Geti 1.1
+    lifecycle_stage: Optional[str] = attr.field(default=None)  # Added in Geti v2.8
 
 
 @attr.define(slots=False)

--- a/tests/pre-merge/unit/utils/test_utils_unit.py
+++ b/tests/pre-merge/unit/utils/test_utils_unit.py
@@ -44,6 +44,9 @@ class TestUtils:
         dictionary_with_nested_extra_key["pipeline"].update(
             {"invalid_key": "invalidness"}
         )
+        dictionary_with_nested_extra_key["pipeline"]["tasks"][0].update(
+            {"another_invalid_key": "invalidness"}
+        )
 
         dictionary_with_missing_key = copy.deepcopy(fxt_project_dictionary)
         dictionary_with_missing_key.pop("pipeline")


### PR DESCRIPTION
### Summary

Bugfix: the `lifecycle_stage` key returned by the model group endpoint would not be recognized and parsed, resulting in errors when calling the `ModelClient` methods.

Ticket: ITEP-67025

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have tested my changes manually.​
- [x] I have added tests to cover my changes.​

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/geti-sdk/blob/main/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
# http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions
# and limitations under the License.
```
