### PR TITLE
Bugfix: unrecognized JobType for import to existing dataset

### DIFF
--- a/geti_sdk/data_models/enums/job_type.py
+++ b/geti_sdk/data_models/enums/job_type.py
@@ -31,6 +31,8 @@ class JobType(Enum):
     TEST = "test"
     PREPARE_IMPORT_TO_NEW_PROJECT = "prepare_import_to_new_project"
     PERFORM_IMPORT_TO_NEW_PROJECT = "perform_import_to_new_project"
+    PREPARE_IMPORT_TO_EXISTING_PROJECT = "prepare_import_to_existing_project"
+    PERFORM_IMPORT_TO_EXISTING_PROJECT = "perform_import_to_existing_project"
     EXPORT_PROJECT = "export_project"
     IMPORT_PROJECT = "import_project"
     EXPORT_DATASET = "export_dataset"

--- a/geti_sdk/data_models/job.py
+++ b/geti_sdk/data_models/job.py
@@ -116,6 +116,8 @@ class DatasetMetadata:
 
     name: Optional[str] = None
     id: Optional[str] = None
+    use_for_training: Optional[bool] = None
+    creation_time: Optional[str] = attr.field(converter=str_to_datetime, default=None)
 
 
 @attr.define


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/geti-sdk/blob/main/CONTRIBUTING.md -->

### Summary

Bugfix: `JobType` enum did not have the values relative to the jobs to import to an existing dataset, sometimes resulting in errors when calling methods of the `TrainClient`.

Ticket: ITEP-67014

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have tested my changes manually.​
- [ ] I have added tests to cover my changes.​

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/geti-sdk/blob/main/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
# http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions
# and limitations under the License.
```
