### PR TITLE
Handles missing prerelease version tag

### DIFF
--- a/geti_sdk/platform_versions.py
+++ b/geti_sdk/platform_versions.py
@@ -40,7 +40,7 @@ class GetiVersion:
         base_version = Version(
             f"{sem_version.major}.{sem_version.minor}.{sem_version.patch}"
         )
-        build_tag = sem_version.prerelease.replace(f"-{time_tag}", "")
+        build_tag = sem_version.prerelease.replace(f"-{time_tag}", "") if sem_version.prerelease else ""
 
         self.version = base_version
         self.build_tag = build_tag


### PR DESCRIPTION
Ensures the `build_tag` attribute is properly set to an empty string when the `sem_version` object does not have a `prerelease` attribute, preventing potential errors.

<!-- Contributing guide: https://github.com/open-edge-platform/geti-sdk/blob/main/CONTRIBUTING.md -->

### Summary

It was impossible to use geti-sdk on the geti 2.9. The reason was prerelease attribute was None, so the calling Geti function always had an exception. This problem is fixed with this pull request.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [X] I have tested my changes manually.​
- [ ] I have added tests to cover my changes.​

### License

- [X] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/geti-sdk/blob/main/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
# http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions
# and limitations under the License.
```
