### PR TITLE
ProjectClient: add method to update label colors/hotkeys [2.10]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## What's Changed
 
 Features:
+* Add new method to update the label colors and hotkeys by @leoll2 in https://github.com/open-edge-platform/geti-sdk/pull/598
 * Added experimental support for keypoint detection by @A-Artemis in https://github.com/open-edge-platform/geti-sdk/pull/588
 
 Bugfixes:


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/geti-sdk/blob/main/CONTRIBUTING.md -->

### Summary

It is now possible to update the colors/hotkeys of the project labels via SDK.

Relates to #597

### How to test

Example:
```python
project = project_client.update_labels(
    project=project,
    colors_to_update={"a": "#ff0000", "b": "#00ff00"},
    hotkeys_to_update={"b": "SHIFT+N", "c": "SHIFT+M"},
)
```

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have tested my changes manually.​
- [ ] I have added tests to cover my changes.​

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/geti-sdk/blob/main/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
# http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions
# and limitations under the License.
```
