### PR TITLE
ITEP-33055: Send empty payload to optimize endpoint

### DIFF
--- a/geti_sdk/benchmarking/benchmarker.py
+++ b/geti_sdk/benchmarking/benchmarker.py
@@ -355,10 +355,7 @@ class Benchmarker:
         :param precision: Precision to use for the optimization
         :return: OptimizedModel object, representing the optimized model
         """
-        optimization_type_map = {"INT8": "pot"}
-        job = self.model_client.optimize_model(
-            model=model, optimization_type=optimization_type_map[precision]
-        )
+        job = self.model_client.optimize_model(model=model)
         self.model_client.monitor_job(job)
         updated_model = self.model_client.update_model_detail(model)
         return updated_model.get_optimized_model(
@@ -517,8 +514,7 @@ class Benchmarker:
         logging.info(f"Initializing Benchmarker from folder `{target_folder}`")
         if len(self._deployment_folders) != 0:
             raise ValueError(
-                "The Benchmarker appears to be already initialized. Unable to "
-                "continue."
+                "The Benchmarker appears to be already initialized. Unable to continue."
             )
         for object in os.listdir(target_folder):
             object_path = os.path.join(target_folder, object)
@@ -629,7 +625,7 @@ class Benchmarker:
                         logging.info(
                             f"Inference model(s) for deployment `{deployment_folder}` "
                             f"loaded. Starting benchmark run. Estimated time required: "
-                            f"{repeats*frames*single_inf_time:.0f} seconds"
+                            f"{repeats * frames * single_inf_time:.0f} seconds"
                         )
                     except Exception as e:
                         success = False

--- a/geti_sdk/rest_clients/model_client.py
+++ b/geti_sdk/rest_clients/model_client.py
@@ -569,8 +569,7 @@ class ModelClient:
         tasks = self.project.get_trainable_tasks()
         model_group: Optional[ModelGroup] = None
         error_msg = (
-            f"Unable to match model '{model}' to any task in project "
-            f"{self.project}. "
+            f"Unable to match model '{model}' to any task in project {self.project}. "
         )
         if model.model_group_id is None:
             raise ValueError(
@@ -605,8 +604,8 @@ class ModelClient:
         Start an optimization job for the specified `model`.
 
         :param model: Model to optimize
-        :param optimization_type: Type of optimization to run. Currently supported
-            values: ["pot", "nncf"]. Case insensitive. Defaults to "pot"
+        :param optimization_type: DEPRECATED. Type of optimization to run. Currently
+            supported values: ["pot"]. Case insensitive. Defaults to "pot"
         :return: Job object referring to the optimization job running on the
             Intel® Geti™ server.
         """
@@ -615,7 +614,7 @@ class ModelClient:
                 f"Model {model.name} is already optimized, please specify a base "
                 f"model for optimization instead."
             )
-        valid_optimization_types = ["pot", "nncf"]
+        valid_optimization_types = ["pot"]
         optimization_type = optimization_type.lower()
         if optimization_type not in valid_optimization_types:
             raise ValueError(
@@ -623,10 +622,7 @@ class ModelClient:
                 f"options are: {valid_optimization_types}"
             )
         optimize_model_url = model.base_url + ":optimize"
-        payload = {
-            "enable_nncf_optimization": optimization_type == "nncf",
-            "enable_pot_optimization": optimization_type == "pot",
-        }
+        payload = {}
         response = self.session.get_rest_response(
             url=optimize_model_url, method="POST", data=payload
         )

--- a/tests/pre-merge/unit/benchmarking/test_benchmarker.py
+++ b/tests/pre-merge/unit/benchmarking/test_benchmarker.py
@@ -226,7 +226,7 @@ class TestBenchmarker:
 
         # Assert
         fxt_benchmarker_task_chain.model_client.optimize_model.assert_called_once_with(
-            model=model, optimization_type="pot"
+            model=model
         )
         assert (
             optimized_model


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/geti-sdk/blob/main/CONTRIBUTING.md -->

### Summary

Send empty payload to optimize endpoint, since there is only one possible optimize method left, POT. Also deprecated optimization type input parameter.

### How to test

Optimize endpoint already accepts empty payload and NNCF support was removed already.

### Checklist

- [ ] I have tested my changes manually.​
- [ ] I have added tests to cover my changes.​

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/geti-sdk/blob/main/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).
