### PR TITLE
move ipython dependency to notebooks extra

### DIFF
--- a/geti_sdk/prediction_visualization/visualizer.py
+++ b/geti_sdk/prediction_visualization/visualizer.py
@@ -19,7 +19,6 @@ from typing import List, Optional, Union
 
 import cv2
 import numpy as np
-from IPython.display import display
 from PIL import Image
 
 from geti_sdk.data_models.annotation_scene import AnnotationScene
@@ -179,6 +178,13 @@ class Visualizer:
 
         :param image: Image to be shown in RGB format
         """
+        try:
+            from IPython.display import display
+        except ImportError as exc:
+            raise ImportError(
+                "IPython is required to display images in a notebook. "
+                "Please install the SDK with the 'notebooks' extra: 'geti-sdk[notebooks]'"
+            ) from exc
         display(Image.fromarray(image))
 
     def show_window(self, image: np.ndarray) -> None:

--- a/geti_sdk/utils/plot_helpers.py
+++ b/geti_sdk/utils/plot_helpers.py
@@ -16,7 +16,6 @@ from typing import List, Optional, Union
 
 import cv2
 import numpy as np
-from IPython.display import display
 from PIL import Image as PILImage
 
 from geti_sdk.data_models.annotation_scene import AnnotationScene
@@ -112,6 +111,13 @@ def show_image_with_annotation_scene(
             if not show_in_notebook:
                 image.show(title=window_name)
             else:
+                try:
+                    from IPython.display import display
+                except ImportError as exc:
+                    raise ImportError(
+                        "IPython is required to display images in a notebook. "
+                        "Please install the SDK with the 'notebooks' extra: 'geti-sdk[notebooks]'"
+                    ) from exc
                 display(image)
     else:
         success, buffer = cv2.imencode(".jpg", result_bgr)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
     "datumaro~=1.10",
     "defusedxml~=0.7",
     "imageio-ffmpeg~=0.6",
-    "ipython~=8.18",
     "joblib~=1.5",
     "numpy~=1.26.4",
     "omegaconf~=2.3",
@@ -73,8 +72,8 @@ docs = [
 ]
 notebooks = [
     "ipywidgets~=8.1",
-    "jupyterlab~=4.0",
-    "jupyter-core~=4.11",
+    "jupyter-core>=5.8.1",  # min version set by CVE-2025-30167
+    "jupyterlab~=4.4",
     "mistune~=2.0",
     "pandas~=2.3",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -860,7 +860,6 @@ dependencies = [
     { name = "datumaro" },
     { name = "defusedxml" },
     { name = "imageio-ffmpeg" },
-    { name = "ipython" },
     { name = "joblib" },
     { name = "numpy" },
     { name = "omegaconf" },
@@ -915,11 +914,10 @@ requires-dist = [
     { name = "datumaro", specifier = "~=1.10" },
     { name = "defusedxml", specifier = "~=0.7" },
     { name = "imageio-ffmpeg", specifier = "~=0.6" },
-    { name = "ipython", specifier = "~=8.18" },
     { name = "ipywidgets", marker = "extra == 'notebooks'", specifier = "~=8.1" },
     { name = "joblib", specifier = "~=1.5" },
-    { name = "jupyter-core", marker = "extra == 'notebooks'", specifier = "~=4.11" },
-    { name = "jupyterlab", marker = "extra == 'notebooks'", specifier = "~=4.0" },
+    { name = "jupyter-core", marker = "extra == 'notebooks'", specifier = ">=5.8.1" },
+    { name = "jupyterlab", marker = "extra == 'notebooks'", specifier = "~=4.4" },
     { name = "mistune", marker = "extra == 'notebooks'", specifier = "~=2.0" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = "~=2.0" },
     { name = "numpy", specifier = "~=1.26.4" },
@@ -1423,15 +1421,16 @@ wheels = [
 
 [[package]]
 name = "jupyter-core"
-version = "4.12.0"
+version = "5.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "platformdirs" },
     { name = "pywin32", marker = "platform_python_implementation != 'PyPy' and sys_platform == 'win32'" },
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/d9/0d18cbe8d0d2eb165dd0b42266f0e5e31b1f80c3a48031fbef1077c34521/jupyter_core-4.12.0.tar.gz", hash = "sha256:87f39d7642412ae8a52291cc68e71ac01dfa2c735df2701f8108251d51b4f460", size = 74760, upload-time = "2022-11-28T13:35:52.005Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/1b/72906d554acfeb588332eaaa6f61577705e9ec752ddb486f302dafa292d9/jupyter_core-5.8.1.tar.gz", hash = "sha256:0a5f9706f70e64786b75acba995988915ebd4601c8a52e534a40b51c95f59941", size = 88923, upload-time = "2025-05-27T07:38:16.655Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/8f/0e0ad6804c0a021a27410ec997626a7a955c20916454d0205f16eb83de4b/jupyter_core-4.12.0-py3-none-any.whl", hash = "sha256:a54672c539333258495579f6964144924e0aa7b07f7069947bef76d7ea5cb4c1", size = 89940, upload-time = "2022-11-28T13:35:50.121Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/57/6bffd4b20b88da3800c5d691e0337761576ee688eb01299eae865689d2df/jupyter_core-5.8.1-py3-none-any.whl", hash = "sha256:c28d268fc90fb53f1338ded2eb410704c5449a358406e8a948b75706e24863d0", size = 28880, upload-time = "2025-05-27T07:38:15.137Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Summary

Changes:
- make `IPython` dependency optional: it is now installed only with the `notebooks` extras
- update `jupyter-core` version to prevent CVE-2025-30167

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have tested my changes manually.​
- [ ] I have added tests to cover my changes.​

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/geti-sdk/blob/main/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
# http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions
# and limitations under the License.
```
