### PR TITLE
ITEP-70998- Bugfix: inference for keypoint detection crashes

### DIFF
--- a/geti_sdk/deployment/deployed_model.py
+++ b/geti_sdk/deployment/deployed_model.py
@@ -801,6 +801,10 @@ class DeployedModel(OptimizedModel):
                     if isinstance(item, str) and item.lower() == "none":
                         value_list.append(None)
                         continue
+                    if child.tag == "labels":
+                        # Do not try to parse labels as floats
+                        value_list.append(item)
+                        continue
                     try:
                         value_list.append(float(item))
                     except ValueError:

--- a/geti_sdk/deployment/predictions_postprocessing/results_converter/results_to_prediction_converter.py
+++ b/geti_sdk/deployment/predictions_postprocessing/results_converter/results_to_prediction_converter.py
@@ -59,7 +59,7 @@ class InferenceResultsToPredictionConverter(metaclass=abc.ABCMeta):
         label_ids = configuration["label_ids"]
         # configuration["labels"] can be a single string or a list of strings
         model_api_labels = (
-            model_api_labels.split() # space separated string
+            model_api_labels.split()  # space separated string
             if isinstance(model_api_labels, str)
             else [str(name) for name in model_api_labels]
         )
@@ -102,9 +102,13 @@ class InferenceResultsToPredictionConverter(metaclass=abc.ABCMeta):
                 if label_id_str in self.label_map_ids:
                     # Get the label by its ID in case it has been renamed
                     label = self.label_map_ids[label_id_str]
-                    logging.warning(f"Label '{label_str}' has been renamed to '{label.name}'.")
+                    logging.warning(
+                        f"Label '{label_str}' has been renamed to '{label.name}'."
+                    )
                 else:
-                    logging.warning(f"Label '{label_str}' cannot be found. It may have been removed.")
+                    logging.warning(
+                        f"Label '{label_str}' cannot be found. It may have been removed."
+                    )
             self.idx_to_label[i] = label
             self.str_to_label[label_str] = label
             self.model_api_label_map_counts[label_str] += 1

--- a/geti_sdk/deployment/predictions_postprocessing/results_converter/results_to_prediction_converter.py
+++ b/geti_sdk/deployment/predictions_postprocessing/results_converter/results_to_prediction_converter.py
@@ -56,7 +56,7 @@ class InferenceResultsToPredictionConverter(metaclass=abc.ABCMeta):
     def __init__(self, labels: LabelList, configuration: Dict[str, Any]):
         self.labels = labels.get_non_empty_labels()
         model_api_labels = configuration["labels"]
-        label_ids = configuration["label_ids"]
+        label_ids = configuration.get("label_ids", [])  # default to empty list
         # configuration["labels"] can be a single string or a list of strings
         model_api_labels = (
             model_api_labels.split()  # space separated string

--- a/geti_sdk/deployment/predictions_postprocessing/results_converter/results_to_prediction_converter.py
+++ b/geti_sdk/deployment/predictions_postprocessing/results_converter/results_to_prediction_converter.py
@@ -56,9 +56,10 @@ class InferenceResultsToPredictionConverter(metaclass=abc.ABCMeta):
     def __init__(self, labels: LabelList, configuration: Dict[str, Any]):
         self.labels = labels.get_non_empty_labels()
         model_api_labels = configuration["labels"]
+        label_ids = configuration["label_ids"]
         # configuration["labels"] can be a single string or a list of strings
         model_api_labels = (
-            [model_api_labels]
+            model_api_labels.split() # space separated string
             if isinstance(model_api_labels, str)
             else [str(name) for name in model_api_labels]
         )
@@ -81,10 +82,19 @@ class InferenceResultsToPredictionConverter(metaclass=abc.ABCMeta):
         self.idx_to_label = {}
         self.str_to_label = {}
         self.model_api_label_map_counts: dict[str, int] = defaultdict(int)
-        for i, label_str in enumerate(model_api_labels):
-            label = self.__get_label(
-                label_str, pos_idx=self.model_api_label_map_counts[label_str]
-            )
+        # Assumes configuration['label_ids'] and configuration['labels'] have the same ordering
+        for i, (label_id_str, label_str) in enumerate(zip(label_ids, model_api_labels)):
+            try:
+                label = self.__get_label(
+                    label_str, pos_idx=self.model_api_label_map_counts[label_str]
+                )
+            except ValueError as e:
+                if label_id_str in self.label_map_ids:
+                    # Get the label by its ID in case it has been renamed
+                    label = self.label_map_ids[label_id_str]
+                    logging.warning(f"Label '{label_str}' has been renamed to '{label.name}'.")
+                else:
+                    logging.warning(f"Label '{label_str}' cannot be found. It may have been removed.")
             self.idx_to_label[i] = label
             self.str_to_label[label_str] = label
             self.model_api_label_map_counts[label_str] += 1


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/geti-sdk/blob/main/CONTRIBUTING.md -->

### Summary

1.  Fixes an issue where labels were being converted from strings to floats (e.g., "label name" -> `LabelName`, `"1"` -> `1.0`). Label names should be treated as strings, not converted numerically.

2.  Prevents label renaming issues after training. If a model is trained with specific label names, e.g., `["1", "2", "3"]`, and those labels are later renamed (e.g., to `["one", "2", "3"]`), infer the correct label by the XML configuration "label_ids". 

<!--
Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).

This PR introduces this capability to make the project better in this and that.

- Added this feature
- Removed that feature
- Fixed the problem #1234
-->

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have tested my changes manually.​
- [ ] I have added tests to cover my changes.​

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/geti-sdk/blob/main/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
# http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions
# and limitations under the License.
```
