### PR TITLE
ITEP-70633: Deprecate Datumaro classes

### DIFF
--- a/geti_sdk/annotation_readers/datumaro_annotation_reader/datumaro_annotation_reader.py
+++ b/geti_sdk/annotation_readers/datumaro_annotation_reader/datumaro_annotation_reader.py
@@ -27,11 +27,20 @@ from geti_sdk.data_models import TaskType
 from geti_sdk.data_models.enums.task_type import GLOBAL_TASK_TYPES
 from geti_sdk.data_models.media import MediaInformation
 from geti_sdk.rest_converters import AnnotationRESTConverter
-from geti_sdk.utils import generate_segmentation_labels, get_dict_key_from_value
+from geti_sdk.utils import (
+    deprecate,
+    generate_segmentation_labels,
+    get_dict_key_from_value,
+)
 
 from .datumaro_dataset import DatumaroDataset
 
 
+@deprecate(
+    since="2.12",
+    use="GetiIE",
+    reason="Dataset and annotations can be imported using Geti's native Dataset Import/Export functionality.",
+)
 class DatumAnnotationReader(AnnotationReader):
     """
     Class to read annotations using datumaro

--- a/geti_sdk/annotation_readers/datumaro_annotation_reader/datumaro_annotation_reader.py
+++ b/geti_sdk/annotation_readers/datumaro_annotation_reader/datumaro_annotation_reader.py
@@ -37,8 +37,8 @@ from .datumaro_dataset import DatumaroDataset
 
 
 @deprecate(
-    since="2.12",
-    use="GetiIE",
+    since="2.11",
+    use="geti_sdk.import_export.GetiIE",
     reason="Dataset and annotations can be imported using Geti's native Dataset Import/Export functionality.",
 )
 class DatumAnnotationReader(AnnotationReader):

--- a/geti_sdk/annotation_readers/datumaro_annotation_reader/datumaro_dataset.py
+++ b/geti_sdk/annotation_readers/datumaro_annotation_reader/datumaro_dataset.py
@@ -32,8 +32,8 @@ from geti_sdk.utils import deprecate, get_dict_key_from_value
 
 
 @deprecate(
-    since="2.12",
-    use="GetiIE",
+    since="2.11",
+    use="geti_sdk.import_export.GetiIE",
     reason="Dataset and annotations can be imported using Geti's native Dataset Import/Export functionality.",
 )
 class DatumaroDataset(object):

--- a/geti_sdk/annotation_readers/datumaro_annotation_reader/datumaro_dataset.py
+++ b/geti_sdk/annotation_readers/datumaro_annotation_reader/datumaro_dataset.py
@@ -28,9 +28,14 @@ from datumaro.components.dataset_base import DatasetItem
 from datumaro.components.environment import Environment
 
 from geti_sdk.data_models import TaskType
-from geti_sdk.utils import get_dict_key_from_value
+from geti_sdk.utils import deprecate, get_dict_key_from_value
 
 
+@deprecate(
+    since="2.12",
+    use="GetiIE",
+    reason="Dataset and annotations can be imported using Geti's native Dataset Import/Export functionality.",
+)
 class DatumaroDataset(object):
     """
     Wrapper for interacting with the datumaro dataset, contains some example

--- a/geti_sdk/utils/__init__.py
+++ b/geti_sdk/utils/__init__.py
@@ -24,6 +24,7 @@ Module contents
 
 from .algorithm_helpers import get_default_algorithm_info, get_supported_algorithms
 from .credentials_helpers import get_server_details_from_env
+from .deprecation import deprecate
 from .dictionary_helpers import get_dict_key_from_value
 from .label_helpers import (
     generate_classification_labels,
@@ -39,6 +40,7 @@ from .serialization_helpers import deserialize_dictionary
 from .workspace_helpers import get_workspace_id
 
 __all__ = [
+    "deprecate",
     "get_workspace_id",
     "generate_classification_labels",
     "generate_segmentation_labels",

--- a/geti_sdk/utils/deprecation.py
+++ b/geti_sdk/utils/deprecation.py
@@ -20,7 +20,7 @@ The utilities help maintain backward compatibility while encouraging users to
 migrate to newer APIs.
 
 Example:
-    >>> from anomalib.utils.deprecation import deprecated
+    >>> from geti_sdk.utils.deprecation import deprecated
 
     >>> # Deprecation without any information
     >>> @deprecate

--- a/geti_sdk/utils/deprecation.py
+++ b/geti_sdk/utils/deprecation.py
@@ -52,7 +52,7 @@ import inspect
 import warnings
 from collections.abc import Callable
 from functools import wraps
-from typing import Any, TypeVar, overload
+from typing import Any, Optional, TypeVar, overload
 
 _T = TypeVar("_T")
 
@@ -64,10 +64,10 @@ def deprecate(__obj: _T) -> _T: ...
 @overload
 def deprecate(
     *,
-    since: str | None = None,
-    remove: str | None = None,
-    use: str | None = None,
-    reason: str | None = None,
+    since: Optional[str] = None,
+    remove: Optional[str] = None,
+    use: Optional[str] = None,
+    reason: Optional[str] = None,
     warning_category: type[Warning] = FutureWarning,
 ) -> Callable[[_T], _T]: ...
 
@@ -75,10 +75,10 @@ def deprecate(
 def deprecate(
     __obj: Any = None,
     *,
-    since: str | None = None,
-    remove: str | None = None,
-    use: str | None = None,
-    reason: str | None = None,
+    since: Optional[str] = None,
+    remove: Optional[str] = None,
+    use: Optional[str] = None,
+    reason: Optional[str] = None,
     warning_category: type[Warning] = FutureWarning,
 ) -> Any:
     """

--- a/geti_sdk/utils/deprecation.py
+++ b/geti_sdk/utils/deprecation.py
@@ -1,0 +1,174 @@
+# Copyright (C) 2025 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions
+# and limitations under the License.
+
+"""
+Deprecation utilities for Geti SDK.
+
+This module provides utilities for marking functions and classes as deprecated.
+The utilities help maintain backward compatibility while encouraging users to
+migrate to newer APIs.
+
+Example:
+    >>> from anomalib.utils.deprecation import deprecated
+
+    >>> # Deprecation without any information
+    >>> @deprecate
+    ... def old_function():
+    ...     pass
+
+    >>> # Deprecation with replacement function
+    >>> @deprecate(use="new_function")
+    ... def old_function():
+    ...     pass
+
+    >>> # Deprecation with version info and replacement class
+    >>> @deprecate(since="2.1.0", remove="2.5.0", use="NewClass")
+    ... class OldClass:
+    ...     pass
+
+    >>> # Deprecation with only removal version
+    >>> @deprecate(remove="2.5.0")
+    ... def another_function():
+    ...     pass
+
+    >>> # Deprecation with only deprecation version
+    >>> @deprecate(since="2.1.0")
+    ... def yet_another_function():
+    ...     pass
+"""
+
+import inspect
+import warnings
+from collections.abc import Callable
+from functools import wraps
+from typing import Any, TypeVar, overload
+
+_T = TypeVar("_T")
+
+
+@overload
+def deprecate(__obj: _T) -> _T: ...
+
+
+@overload
+def deprecate(
+    *,
+    since: str | None = None,
+    remove: str | None = None,
+    use: str | None = None,
+    reason: str | None = None,
+    warning_category: type[Warning] = FutureWarning,
+) -> Callable[[_T], _T]: ...
+
+
+def deprecate(
+    __obj: Any = None,
+    *,
+    since: str | None = None,
+    remove: str | None = None,
+    use: str | None = None,
+    reason: str | None = None,
+    warning_category: type[Warning] = FutureWarning,
+) -> Any:
+    """
+    Mark a function or class as deprecated.
+
+    This decorator will cause a warning to be emitted when the function is called or class is instantiated.
+
+    Example:
+        >>> # Basic deprecation without any information
+        >>> @deprecate
+        ... def old_function():
+        ...     pass
+
+        >>> # Deprecation with version info and replacement class
+        >>> @deprecate(since="2.1.0", remove="2.5.0", use="NewClass")
+        ... class OldClass:
+        ...     pass
+
+        >>> # Deprecation with only removal version
+        >>> @deprecate(remove="2.5.0")
+        ... def another_function():
+        ...     pass
+
+        >>> # Deprecation with only deprecation version
+        >>> @deprecate(since="2.1.0")
+        ... def yet_another_function():
+        ...     pass
+
+        >>> # Deprecation with reason and custom warning category
+        >>> @deprecate(since="2.1.0", reason="Performance improvements available", warning_category=FutureWarning)
+        ... def old_slow_function():
+        ...     pass
+
+    :param __obj: The function or class to be deprecated.
+            If provided, the decorator is used without arguments.
+            If None, the decorator is used with arguments.
+    :param since: Version when the function/class was deprecated (e.g. "2.1.0").
+            If not provided, no deprecation version will be shown in the warning message.
+    :param remove: Version when the function/class will be removed.
+            If not provided, no removal version will be shown in the warning message.
+    :param use: Name of the replacement function/class.
+            If not provided, no replacement suggestion will be shown in the warning message.
+    :param reason: Additional reason for the deprecation.
+            If not provided, no reason will be shown in the warning message.
+    :param warning_category: Type of warning to emit (default: FutureWarning).
+            Can be DeprecationWarning, FutureWarning, PendingDeprecationWarning, etc.
+    :return: Decorated function/class that emits a deprecation warning when used.
+    """
+
+    def _deprecate_impl(obj: Any) -> Any:  # noqa: ANN401
+        if isinstance(obj, type):
+            # Handle class deprecation
+            original_init = inspect.getattr_static(obj, "__init__")
+
+            @wraps(original_init)
+            def new_init(self: Any, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401
+                msg = f"{obj.__name__} is deprecated"
+                if since:
+                    msg += f" since v{since}"
+                if remove:
+                    msg += f" and will be removed in v{remove}"
+                if use:
+                    msg += f". Use {use} instead"
+                if reason:
+                    msg += f". {reason}"
+                msg += "."
+                warnings.warn(msg, warning_category, stacklevel=2)
+                original_init(self, *args, **kwargs)
+
+            setattr(obj, "__init__", new_init)  # noqa: B010
+            return obj
+
+        # Handle function deprecation
+        @wraps(obj)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401
+            msg = f"{obj.__name__} is deprecated"
+            if since:
+                msg += f" since v{since}"
+            if remove:
+                msg += f" and will be removed in v{remove}"
+            if use:
+                msg += f". Use {use} instead"
+            if reason:
+                msg += f". {reason}"
+            msg += "."
+            warnings.warn(msg, warning_category, stacklevel=2)
+            return obj(*args, **kwargs)
+
+        return wrapper
+
+    if __obj is None:
+        return _deprecate_impl
+    return _deprecate_impl(__obj)


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/geti-sdk/blob/main/CONTRIBUTING.md -->

### Summary

Deprecate old Datumaro classes. These classes were introduced before the native Geti Dataset Improt/Export functionality was supported. The recommended way of importing annotations/datasets has been through Geti Dataset import/export instead for a long time now. We deprecate these classes, because they make Geti SDK depend on datumaro, which is a pretty heavy dependency. In the future we will remove these classes and their dependencies from the Geti SDK.

### How to test
Everything should work as before, except a FutureWarning should be raised whenever someone initializes a DatumaroAnnotationReader or Dataset class.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have tested my changes manually.​
- [ ] I have added tests to cover my changes.​

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/geti-sdk/blob/main/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
# http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions
# and limitations under the License.
```
