### PR TITLE
ITEP-71447 Show keypoint predictions on image

### DIFF
--- a/geti_sdk/prediction_visualization/shape_drawer.py
+++ b/geti_sdk/prediction_visualization/shape_drawer.py
@@ -741,10 +741,12 @@ class ShapeDrawer(DrawerEntity[AnnotationScene]):
 
             return image
 
-    class KeypointDrawer(Helpers, DrawerEntity[Polygon]):
+    class KeypointDrawer(Helpers, DrawerEntity[Keypoint]):
         """
         Class to draw keypoints on an image.
         """
+
+        supported_types = [Keypoint]
 
         def __init__(self, show_labels, show_confidence):
             super().__init__()
@@ -767,7 +769,8 @@ class ShapeDrawer(DrawerEntity[AnnotationScene]):
             :param fill_shapes: Whether to fill the shapes with color.
             :return: Image with the keypoint drawn on it
             """
-            radius = 5
+            smaller_side = min(image.shape[0], image.shape[1])
+            radius = max(round(smaller_side * 0.01), 1)
 
             circle = cv2.circle(
                 image,
@@ -792,11 +795,11 @@ class ShapeDrawer(DrawerEntity[AnnotationScene]):
             # Get top edge of keypoint
             offset = self.label_offset_box_shape
             x_coord = entity.x
-            y_coord = entity.y * image.shape[0] - radius - offset
+            y_coord = entity.y - radius - offset
 
             # Put label at bottom if it is out of bounds at the top of the shape, and shift label to left if needed
             if y_coord < self.top_margin * image.shape[0]:
-                y_coord = entity.y * image.shape[0] + radius + offset
+                y_coord = entity.y + radius + offset
 
             if x_coord + content_width > circle.shape[1]:
                 # The list of labels is too close to the right side of the image.


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/geti-sdk/blob/main/CONTRIBUTING.md -->

### Summary

Fixes an issue with the keypoint predictions not showing on the image for the demo.py from the code deployment.
The Keypoint drawer did not have its default supported type set.
Also addresses an issue with the position and scale of the drawn circles.

### How to test


### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have tested my changes manually.​
- [ ] I have added tests to cover my changes.​

### License

- [ ] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/geti-sdk/blob/main/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
# http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions
# and limitations under the License.
```
