### PR TITLE
bugfix: cannot find project after import

### DIFF
--- a/geti_sdk/import_export/import_export_module.py
+++ b/geti_sdk/import_export/import_export_module.py
@@ -482,8 +482,17 @@ class GetiIE:
         )
 
         job = monitor_job(session=self.session, job=job, interval=5)
+        if not job.metadata.project.id:
+            # Wait a few seconds for the metadata to become in sync
+            time.sleep(3)
+            job = get_job_with_timeout(
+                job_id=job.id,
+                session=self.session,
+                workspace_id=self.workspace_id,
+                job_type="import_project",
+            )
         imported_project = self.project_client.get_project(
-            project_id=job.metadata.project_id,
+            project_id=job.metadata.project.id,
         )
         if imported_project is None:
             raise RuntimeError(


### PR DESCRIPTION
### Summary

Fix a bug where `GetiIE.import_project` would sometimes fail to retrieve the project right after importing it. This is caused by eventual consistency in the Geti job metadata; after waiting for a few second, the method now refreshes the job metadata to find the project id.

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have tested my changes manually.​
- [ ] I have added tests to cover my changes.​
