### PR TITLE
bugfix: `ModelClient.get_all_model_groups` would fail with visual prompting models

### DIFF
--- a/geti_sdk/rest_clients/model_client.py
+++ b/geti_sdk/rest_clients/model_client.py
@@ -65,7 +65,10 @@ class ModelClient:
         model_groups = [ModelRESTConverter.model_group_from_dict(group) for group in response_array]
         # Update algorithm details
         for group in model_groups:
-            group.algorithm = self.supported_algos.get_by_model_manifest_id(model_manifest_id=group.model_template_id)
+            if group.learning_approach == "fully_supervised":  # only fully supervised models have a manifest
+                group.algorithm = self.supported_algos.get_by_model_manifest_id(
+                    model_manifest_id=group.model_template_id
+                )
             for model in group.models:
                 # set the model storage id, to link models to their parent group
                 model.model_storage_id = group.id


### PR DESCRIPTION
### Summary

In projects that have visual prompting models, the method `ModelClient.get_all_model_groups` would fail when trying to retrieve the (non-existing) manifests of these models.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have tested my changes manually.​
- [ ] I have added tests to cover my changes.​
