### PR TITLE
rebranding of Geti

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v2.12.0 Intel® Geti™ SDK
+# v2.12.0 Geti™ SDK
 
 ## What's Changed
 
@@ -47,7 +47,7 @@
 **Full Changelog**: https://github.com/open-edge-platform/geti-sdk/compare/v2.11.0...v2.12.0
 
 
-# v2.11.0 Intel® Geti™ SDK (15-07-2025)
+# v2.11.0 Geti™ SDK (15-07-2025)
 
 ## What's Changed
 
@@ -76,7 +76,7 @@
 **Full Changelog**: https://github.com/open-edge-platform/geti-sdk/compare/v2.10.2...v2.11.0
 
 
-# v2.10.2 Intel® Geti™ SDK (04-07-2025)
+# v2.10.2 Geti™ SDK (04-07-2025)
 ## What's Changed
 
 Bugfixes:
@@ -85,7 +85,7 @@ Bugfixes:
 **Full Changelog**: https://github.com/open-edge-platform/geti-sdk/compare/v2.10.1...v2.10.2
 
 
-# v2.10.1 Intel® Geti™ SDK (30-06-2025)
+# v2.10.1 Geti™ SDK (30-06-2025)
 ## What's Changed
 
 Bugfixes:
@@ -94,7 +94,7 @@ Bugfixes:
 **Full Changelog**: https://github.com/open-edge-platform/geti-sdk/compare/v2.10.0...v2.10.1
 
 
-# v2.10.0 Intel® Geti™ SDK (30-05-2025)
+# v2.10.0 Geti™ SDK (30-05-2025)
 ## What's Changed
 
 Features:
@@ -125,10 +125,10 @@ Extra:
 **Full Changelog**: https://github.com/open-edge-platform/geti-sdk/compare/v2.8.0...v2.10.0
 
 
-# v2.9.0 Intel® Geti™ SDK (skipped)
+# v2.9.0 Geti™ SDK (skipped)
 
 
-# v2.8.0 Intel® Geti™ SDK (17-03-2025)
+# v2.8.0 Geti™ SDK (17-03-2025)
 ## What's Changed
 
 * Bugfix: inference would sometimes fail if labels have number-like names by @maxxgx in https://github.com/openvinotoolkit/geti-sdk/pull/567
@@ -139,7 +139,7 @@ Extra:
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v2.7.1...v2.8.0
 
 
-# v2.7.1 Intel® Geti™ SDK (26-02-2025)
+# v2.7.1 Geti™ SDK (26-02-2025)
 ## What's Changed
 
 * Bugfix: automatic workspace selection would sometimes not work by @leoll2 in https://github.com/openvinotoolkit/geti-sdk/pull/565
@@ -147,7 +147,7 @@ Extra:
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v2.7.0...v.2.7.1
 
 
-# v2.7.0 Intel® Geti™ SDK (17-02-2025)
+# v2.7.0 Geti™ SDK (17-02-2025)
 ## What's Changed
 
 * Added support for Python 3.12 by @gdlg in https://github.com/openvinotoolkit/geti-sdk/pull/549
@@ -163,14 +163,14 @@ Extra:
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v2.6.2...v.2.7.0
 
 
-# v2.6.2 Intel® Geti™ SDK (08-01-2025)
+# v2.6.2 Geti™ SDK (08-01-2025)
 ## What's Changed
 * Bugfix: inference not working for classification projects with label containing spaces in their name by @maxxgx in https://github.com/openvinotoolkit/geti-sdk/pull/539
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v2.6.1...v2.6.2
 
 
-# v2.6.1 Intel® Geti™ SDK (02-01-2025)
+# v2.6.1 Geti™ SDK (02-01-2025)
 ## What's Changed
 * Bugfix: empty label sometimes not recognized during inference by @maxxgx in https://github.com/openvinotoolkit/geti-sdk/pull/534
 
@@ -180,7 +180,7 @@ Extra:
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v2.6.0...v2.6.1
 
 
-# v2.6.0 Intel® Geti™ SDK (26-12-2024)
+# v2.6.0 Geti™ SDK (26-12-2024)
 ## What's Changed
 * Updated model representation to that of Geti V2.6 by @Daankrol in https://github.com/openvinotoolkit/geti-sdk/pull/523
 * Mark model response fields as deprecated in 2.6 instead of removed by @leoll2 in https://github.com/openvinotoolkit/geti-sdk/pull/528
@@ -191,7 +191,7 @@ Extra:
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v2.5.0...v2.6.0
 
 
-# v2.5.0 Intel® Geti™ SDK (22-10-2024)
+# v2.5.0 Geti™ SDK (22-10-2024)
 ## What's Changed
 * Introduce `delete_dataset` method  by @igor-davidyuk in https://github.com/openvinotoolkit/geti-sdk/pull/489
 * Update the download_all method for ImageClient to download specific dataset by @rajeshgangireddy in https://github.com/openvinotoolkit/geti-sdk/pull/484
@@ -220,7 +220,7 @@ Extra:
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v2.3.0...v2.5.0
 
 
-# v2.3.0 Intel® Geti™ SDK (03-09-2024)
+# v2.3.0 Geti™ SDK (03-09-2024)
 ## What's Changed
 * Add method to purge models by @igor-davidyuk in https://github.com/openvinotoolkit/geti-sdk/pull/468
 * Fix visualization in 008 example notebook by @igor-davidyuk in https://github.com/openvinotoolkit/geti-sdk/pull/472
@@ -234,7 +234,7 @@ Extra:
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v2.2.0...v2.3.0
 
 
-# v2.2.0 Intel® Geti™ SDK (18-07-2024)
+# v2.2.0 Geti™ SDK (18-07-2024)
 ## What's Changed
 * Add `description` attribute to the job class by @igor-davidyuk in https://github.com/openvinotoolkit/geti-sdk/pull/448
 * Project/Dataset export import API alignment by @igor-davidyuk in https://github.com/openvinotoolkit/geti-sdk/pull/446
@@ -259,7 +259,7 @@ Extra:
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/releases/v2.1.0...1234
 
-# v2.1.0 Intel® Geti™ SDK (19-06-2024)
+# v2.1.0 Geti™ SDK (19-06-2024)
 ## What's Changed
 * Saliency map visualization by @igor-davidyuk in https://github.com/openvinotoolkit/geti-sdk/pull/424
 * Add a model management notebook by @igor-davidyuk in https://github.com/openvinotoolkit/geti-sdk/pull/419
@@ -285,7 +285,7 @@ Extra:
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v2.0.1...v2.1.0
 
-# v2.0.1 Intel® Geti™ SDK (29-05-2024)
+# v2.0.1 Geti™ SDK (29-05-2024)
 ## What's Changed
 * Add retry mechanism to better handle `ConnectionError` by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/420
 * Undo changes to video tempfile handling, register atexit handler for tempfile deletion by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/423
@@ -293,16 +293,16 @@ Extra:
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v2.0.0...v2.0.1
 
-# v2.0.0 Intel® Geti™ SDK (16-05-2024)
+# v2.0.0 Geti™ SDK (16-05-2024)
 ## New features
 This release introduces a new feature related to model deployment: post-inference hooks! A post-inference hook can be added to any `Deployment`, and will be executed after every inference request (i.e. every call to `deployment.infer()`). The hooks allow you to define specific actions to take under certain conditions. For example, a hook could implement the following behaviour:
-**If** the confidence level of one of the predictions for the image is less than 20%, **then** upload the image to the Intel® Geti™ project in which the model was trained.
+**If** the confidence level of one of the predictions for the image is less than 20%, **then** upload the image to the Geti™ project in which the model was trained.
 
 This could be useful for improving your model with a next training round, because including such 'low confidence images' in the training dataset might help to improve model accuracy.
 Additional examples of post-inference hooks, and instructions for configuring them, can be found in the newly added [notebook 012](https://github.com/openvinotoolkit/geti-sdk/blob/main/notebooks/012_post_inference_hooks.ipynb) in this repository.
 
 ## Breaking changes
-This major release of the Intel® Geti™ SDK breaks backwards compatibility with Intel® Geti™ servers of version v1.14 and below. Please make sure that your Intel® Geti™ server is updated to the latest version of the Intel® Geti™ platform, to prevent compatibility issues.
+This major release of the Geti™ SDK breaks backwards compatibility with Geti™ servers of version v1.14 and below. Please make sure that your Geti™ server is updated to the latest version of the Geti™ platform, to prevent compatibility issues.
 
 ## What's Changed
 * Update `Video` data model with annotation statistics by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/391
@@ -338,14 +338,14 @@ This major release of the Intel® Geti™ SDK breaks backwards compatibility wit
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v1.16.1...v2.0.0
 
 
-# v1.16.1 Intel® Geti™ SDK (22-04-2024)
+# v1.16.1 Geti™ SDK (22-04-2024)
 ## What's Changed
 * Add `default_workspace` to possible default workspace names by @igor-davidyuk in https://github.com/openvinotoolkit/geti-sdk/pull/394
 
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v1.16.0...v1.16.1
 
-# v1.16.0 Intel® Geti™ SDK (26-03-2024)
+# v1.16.0 Geti™ SDK (26-03-2024)
 ## What's Changed
 * Decouple visualizer for OTX by @igor-davidyuk in https://github.com/openvinotoolkit/geti-sdk/pull/356
 * Update data models to account for REST API changes in Geti v1.16 by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/357
@@ -357,11 +357,11 @@ This major release of the Intel® Geti™ SDK breaks backwards compatibility wit
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v1.15.0...v1.16.0
 
-# v1.15.0 Intel® Geti™ SDK (12-03-2024)
-This release makes the SDK compatible for Intel® Geti™ v1.15. The majority of the changes is focused on that, but below is a list of other changes that are worth mentioning.
+# v1.15.0 Geti™ SDK (12-03-2024)
+This release makes the SDK compatible for Geti™ v1.15. The majority of the changes is focused on that, but below is a list of other changes that are worth mentioning.
 
 ## Release Highlights
-- Add compatibility for Intel® Geti™ v1.15. Note that we maintain backwards compatibility for models created in Intel® Geti™ v1.8: This means that the SDK can run inference on deployments from both both the latest Intel® Geti™ on-prem release and Intel® Geti™ SaaS.
+- Add compatibility for Geti™ v1.15. Note that we maintain backwards compatibility for models created in Geti™ v1.8: This means that the SDK can run inference on deployments from both both the latest Geti™ on-prem release and Geti™ SaaS.
 - Add benchmarking functionality for deployments through the `Benchmarker` class, as well as a new notebook to demonstrate this feature.
 - Improve the job monitoring feature, job progression is now displayed via progress bars.
 - Image and annotation upload and download now uses multithreading, greatly speeding up the process.
@@ -424,7 +424,7 @@ This release makes the SDK compatible for Intel® Geti™ v1.15. The majority of
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v.1.8.2...v1.15.0
 
-# v1.8.2 Intel® Geti™ SDK (22-02-2024)
+# v1.8.2 Geti™ SDK (22-02-2024)
 ## What's Changed
 * Update `opencv-python` requirement to `4.9.*`
 * Update `Pillow` requirement to `10.2.*`
@@ -434,7 +434,7 @@ This release makes the SDK compatible for Intel® Geti™ v1.15. The majority of
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v.1.8.1...v.1.8.2
 
-# v1.8.1 Intel® Geti™ SDK (20-11-2023)
+# v1.8.1 Geti™ SDK (20-11-2023)
 ## What's Changed
 * Update pytest requirement from ==7.3.* to ==7.4.* in /requirements by @dependabot in https://github.com/openvinotoolkit/geti-sdk/pull/261
 * Update pytest-env requirement from ==0.8.* to ==1.0.* in /requirements by @dependabot in https://github.com/openvinotoolkit/geti-sdk/pull/275
@@ -443,7 +443,7 @@ This release makes the SDK compatible for Intel® Geti™ v1.15. The majority of
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v.1.8.0...v.1.8.1
 
-# v1.8.0 Intel® Geti™ SDK (16-10-2023)
+# v1.8.0 Geti™ SDK (16-10-2023)
 ## What's Changed
 * Predict video on local by @jihyeonyi in https://github.com/openvinotoolkit/geti-sdk/pull/243
 * Update job datamodel for new job scheduler by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/251
@@ -474,7 +474,7 @@ This release makes the SDK compatible for Intel® Geti™ v1.15. The majority of
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v1.5.8...v.1.8.0
 
-# v1.5.8 Intel® Geti™ SDK (19-06-2023)
+# v1.5.8 Geti™ SDK (19-06-2023)
 ## What's Changed
 * Update vcrpy requirement from ==4.2.* to ==4.3.* in /requirements by @dependabot in https://github.com/openvinotoolkit/geti-sdk/pull/227
 * Specify correct project name in notebook 009 by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/229
@@ -490,7 +490,7 @@ This release makes the SDK compatible for Intel® Geti™ v1.15. The majority of
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v1.5.7...v1.5.8
 
-# v1.5.7 Intel® Geti™ SDK (30-05-2023)
+# v1.5.7 Geti™ SDK (30-05-2023)
 ## What's Changed
 * Allow more efficient image uploading for datumaro annotation readers by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/224
 * Fix deployment for `otx v1.2.2` by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/225
@@ -498,7 +498,7 @@ This release makes the SDK compatible for Intel® Geti™ v1.15. The majority of
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v1.5.6...v1.5.7
 
-# v1.5.6 Intel® Geti™ SDK (23-05-2023)
+# v1.5.6 Geti™ SDK (23-05-2023)
 ## What's Changed
 * Add `group` key to hierarchical label definition in notebook 001 by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/220
 * Add `TestingClient` to perform model tests by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/221
@@ -508,14 +508,14 @@ This release makes the SDK compatible for Intel® Geti™ v1.15. The majority of
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v1.5.5...v1.5.6
 
-# v1.5.5 Intel® Geti™ SDK (15-05-2023)
+# v1.5.5 Geti™ SDK (15-05-2023)
 ## What's Changed
 * Add param to disable certificate validation for data download helpers by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/218
 
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v1.5.4...v1.5.5
 
-# v1.5.4 Intel® Geti™ SDK (11-05-2023)
+# v1.5.4 Geti™ SDK (11-05-2023)
 ## What's Changed
 * Add active learning client for retrieving the active set by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/215
 * Allow passing label dictionaries to `Geti.create_single_task_project_from_dataset` by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/216
@@ -524,7 +524,7 @@ This release makes the SDK compatible for Intel® Geti™ v1.15. The majority of
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v1.5.3...v1.5.4
 
-# v1.5.3 Intel® Geti™ SDK (10-05-2023)
+# v1.5.3 Geti™ SDK (10-05-2023)
 ## What's Changed
 * Add `ONNX` as optimization type by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/212
 * Remove trailing slash from the base url in the media rest client by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/214
@@ -534,7 +534,7 @@ This release makes the SDK compatible for Intel® Geti™ v1.15. The majority of
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v1.5.2...v1.5.3
 
-# v1.5.2 Intel® Geti™ SDK (08-05-2023)
+# v1.5.2 Geti™ SDK (08-05-2023)
 ## What's Changed
 * Add score NoneType check in summary function of ProjectStatus by @harimkang in https://github.com/openvinotoolkit/geti-sdk/pull/208
 * Update `OptimizedModel` data model by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/209
@@ -545,7 +545,7 @@ This release makes the SDK compatible for Intel® Geti™ v1.15. The majority of
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v1.5.1...v1.5.2
 
-# v1.5.1 Intel® Geti™ SDK (26-04-2023)
+# v1.5.1 Geti™ SDK (26-04-2023)
 ## What's Changed
 * Update hashing algorithm to `sha3_512` by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/204
 * Bump otx from 1.1.2 to 1.2.0 in /requirements by @dependabot in https://github.com/openvinotoolkit/geti-sdk/pull/203
@@ -554,7 +554,7 @@ This release makes the SDK compatible for Intel® Geti™ v1.15. The majority of
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v1.5.0...v1.5.1
 
-# v1.5.0 Intel® Geti™ SDK (24-04-2023)
+# v1.5.0 Geti™ SDK (24-04-2023)
 ## What's Changed
 * Pin orjson version to 3.8.8 to avoid installation error by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/178
 * Fix nightly tests for classification project by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/179
@@ -585,7 +585,7 @@ This release makes the SDK compatible for Intel® Geti™ v1.15. The majority of
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v1.4.1...v1.5.0
 
-# [Pre-release] v1.4.1 Intel® Geti™ SDK (28-03-2023)
+# [Pre-release] v1.4.1 Geti™ SDK (28-03-2023)
 ## What's Changed
 * Update otx requirement to `otx==1.1.0` by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/176
 * Make model wrapper module namespace unique by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/177
@@ -593,16 +593,16 @@ This release makes the SDK compatible for Intel® Geti™ v1.15. The majority of
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v1.4.0...v1.4.1
 
-# [Pre-release] v1.4.0 Intel® Geti™ SDK (27-03-2023)
+# [Pre-release] v1.4.0 Geti™ SDK (27-03-2023)
 ## What's Changed
 * Migrate from `ote_sdk` to `otx.api` by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/166
 
 ## Caution: Backwards incompatibility for project `Deployments`
-This release breaks backwards compatibility with `deployments` created by earlier versions of the Intel® Geti™ platform. Please only update to this version of the Geti SDK if you are sure that your Intel® Geti™ server is also on version 1.4 or later.
+This release breaks backwards compatibility with `deployments` created by earlier versions of the Geti™ platform. Please only update to this version of the Geti SDK if you are sure that your Geti™ server is also on version 1.4 or later.
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v1.2.4...v1.4.0
 
-# v1.2.4 Intel® Geti™ SDK (27-03-2023)
+# v1.2.4 Geti™ SDK (27-03-2023)
 ## What's Changed
 * Update ipython requirement from ==8.10.* to ==8.11.* in /requirements by @dependabot in https://github.com/openvinotoolkit/geti-sdk/pull/172
 * Fix `upload_and_predict_from_numpy.py` example by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/173
@@ -611,7 +611,7 @@ This release breaks backwards compatibility with `deployments` created by earlie
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v1.2.3...v1.2.4
 
-# v1.2.3 Intel® Geti™ SDK (13-03-2023)
+# v1.2.3 Geti™ SDK (13-03-2023)
 ## What's Changed
 * Fix saving images and annotations with non-ascii characters in their filename by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/160
 * Update tqdm requirement from ==4.64.* to ==4.65.* in /requirements by @dependabot in https://github.com/openvinotoolkit/geti-sdk/pull/161
@@ -631,7 +631,7 @@ This release breaks backwards compatibility with `deployments` created by earlie
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v1.2.2...v1.2.3
 
-# v1.2.2 Intel® Geti™ SDK (28-02-2023)
+# v1.2.2 Geti™ SDK (28-02-2023)
 ## What's Changed
 * Enable OVMS deployment by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/148
 * Minor fixes for notebook 010 by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/149
@@ -645,7 +645,7 @@ This release breaks backwards compatibility with `deployments` created by earlie
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v1.2.1...v1.2.2
 
-# v1.2.1 Intel® Geti™ SDK (02-02-2023)
+# v1.2.1 Geti™ SDK (02-02-2023)
 ## What's Changed
 * Fix issue with deployment for anomaly classification models by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/144
 * Require `mistune>=2.0.3` for notebooks by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/147
@@ -655,7 +655,7 @@ This release breaks backwards compatibility with `deployments` created by earlie
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v1.2.0...v1.2.1
 
-# v1.2 Intel® Geti™ SDK (24-01-2023)
+# v1.2 Geti™ SDK (24-01-2023)
 ## What's Changed
 * Add `size` field to MediaInformation data model by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/133
 * Update available Geti versions by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/134
@@ -674,7 +674,7 @@ This release breaks backwards compatibility with `deployments` created by earlie
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v1.1.1...v1.2.0
 
-# v1.1.1 Intel® Geti™ SDK (20-12-2022)
+# v1.1.1 Geti™ SDK (20-12-2022)
 ## What's Changed
 * Fix issue with model to dictionary conversion by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/128
 * Only submit train request once all running jobs for task have finished by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/129
@@ -682,7 +682,7 @@ This release breaks backwards compatibility with `deployments` created by earlie
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v1.1.0...v1.1.1
 
-# v1.1.0 Intel® Geti™ SDK (15-12-2022)
+# v1.1.0 Geti™ SDK (15-12-2022)
 ## What's Changed
 * Minor fix in README.md by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/118
 * Fix and improve geti version comparison mechanism by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/117
@@ -695,7 +695,7 @@ This release breaks backwards compatibility with `deployments` created by earlie
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v1.0.4...v1.1.0
 
-# v1.0.4 Intel® Geti™ SDK (08-12-2022)
+# v1.0.4 Geti™ SDK (08-12-2022)
 ## What's Changed
 * Update ipython requirement from ==8.6.* to ==8.7.* in /requirements by @dependabot in https://github.com/openvinotoolkit/geti-sdk/pull/112
 * Properly check for empty annotation before uploading by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/111
@@ -707,7 +707,7 @@ This release breaks backwards compatibility with `deployments` created by earlie
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v1.0.3...v1.0.4
 
-# v1.0.3 Intel® Geti™ SDK (25-11-2022)
+# v1.0.3 Geti™ SDK (25-11-2022)
 ## What's Changed
 * Add `ScoreMetadata` to represent the new `scores` field by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/106
 * Add model and prediction client integration tests + update cassettes by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/107
@@ -717,7 +717,7 @@ This release breaks backwards compatibility with `deployments` created by earlie
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v1.0.2...v1.0.3
 
-# v1.0.2 Intel® Geti™ SDK (17-11-2022)
+# v1.0.2 Geti™ SDK (17-11-2022)
 ## What's Changed
 * Update ote-sdk requirement to v0.3.1 by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/98
 * Add integration tests for `project_client`, fix `project_client.add_labels` by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/99
@@ -729,7 +729,7 @@ This release breaks backwards compatibility with `deployments` created by earlie
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v1.0.1...v1.0.2
 
-# v1.0.1 Intel® Geti™ SDK (11-11-2022)
+# v1.0.1 Geti™ SDK (11-11-2022)
 ## What's Changed
 * Add path validation to project download target path by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/87
 * Update tqdm requirement from ==4.62.* to ==4.64.* in /requirements by @dependabot in https://github.com/openvinotoolkit/geti-sdk/pull/84
@@ -737,7 +737,7 @@ This release breaks backwards compatibility with `deployments` created by earlie
 * Add security note to README for project download by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/88
 * Update numpy requirement to 1.21.* by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/89
 * Reduce permissions upon directory creation by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/90
-* Update README to correctly reference Intel Geti brand everywhere by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/92
+* Update README to correctly reference Geti brand everywhere by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/92
 * Improve check for video processing in `Geti.upload_project_data()` to avoid potential infinite loop by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/93
 * Add unit tests to pre-merge test suite by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/91
 * Update ProjectStatus and TaskStatus to include new field `n_new_annotations` by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/94
@@ -747,7 +747,7 @@ This release breaks backwards compatibility with `deployments` created by earlie
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v1.0.0...v1.0.1
 
-# v1.0.0 Intel® Geti™ SDK (04-11-2022)
+# v1.0.0 Geti™ SDK (04-11-2022)
 ## What's Changed
 * Add a re-authentication mechanism when using token authentication by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/72
 * Update pytest requirement from ==7.1.* to ==7.2.* in /requirements by @dependabot in https://github.com/openvinotoolkit/geti-sdk/pull/73
@@ -768,7 +768,7 @@ This release breaks backwards compatibility with `deployments` created by earlie
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v0.2.4...v1.0.0rc1
 
-# v0.2.4 Intel® Geti™ SDK (25-10-2022)
+# v0.2.4 Geti™ SDK (25-10-2022)
 ## What's Changed
 * Auto detect normalized annotation files for GetiAnnotationReader by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/63
 * Fix version detection mechanism and add tests for GetiVersion by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/64
@@ -782,7 +782,7 @@ This release breaks backwards compatibility with `deployments` created by earlie
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v0.2.3...v0.2.4
 
-# v0.2.3 Intel® Geti™ SDK (06-10-2022)
+# v0.2.3 Geti™ SDK (06-10-2022)
 ## What's Changed
 * Remove VCR from nightly test for demos by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/54
 * Improve nightly tests for `demos` module by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/55
@@ -795,7 +795,7 @@ This release breaks backwards compatibility with `deployments` created by earlie
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v0.2.2...v0.2.3
 
-# v0.2.2 Intel® Geti™ SDK (04-10-2022)
+# v0.2.2 Geti™ SDK (04-10-2022)
 ## What's Changed
 * Add coverage report to pre-merge and nightly test artifacts by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/47
 * Correctly set permissions on extracted files for anomaly dataset by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/51
@@ -805,7 +805,7 @@ This release breaks backwards compatibility with `deployments` created by earlie
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v0.2.1...v0.2.2
 
-# v0.2.1 Intel® Geti™ SDK (30-09-2022)
+# v0.2.1 Geti™ SDK (30-09-2022)
 ## What's Changed
 * Replace SC references in docstrings by Geti by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/33
 * Change package name from `geti_sdk` to `geti-sdk`. Import names are unchanged by @ljcornel in https://github.com/openvinotoolkit/geti-sdk/pull/34
@@ -825,20 +825,20 @@ This release breaks backwards compatibility with `deployments` created by earlie
 
 **Full Changelog**: https://github.com/openvinotoolkit/geti-sdk/compare/v0.2.0...v0.2.1
 
-# v0.2.0 Intel® Geti™ SDK (27-09-2022)
+# v0.2.0 Geti™ SDK (27-09-2022)
 
-This is the first official release of the Intel® Geti™ Software Development Kit (SDK).
+This is the first official release of the Geti™ Software Development Kit (SDK).
 
 The purpose of this SDK is twofold:
 
-1. Provide an easy-to-use interface to the [Intel® Geti™ platform](www.geti.intel.com), to manipulate
-Intel® Geti™ projects and other entities or automate tasks on the platform. All
+1. Provide an easy-to-use interface to the [Geti™ platform](www.geti.intel.com), to manipulate
+Geti™ projects and other entities or automate tasks on the platform. All
 of this from a Python script or Jupyter notebook.
 
 
-2. Provide an API to deploy and run models trained on the Intel® Geti™ server on your local
+2. Provide an API to deploy and run models trained on the Geti™ server on your local
 machine. The SDK Deployment module provides a straightforward
-route to create a deployment for your Intel® Geti™ project, save it to a local disk and run
+route to create a deployment for your Geti™ project, save it to a local disk and run
 it offline.
 
 This SDK includes various example scripts and Jupyter notebooks which illustrate a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-We appreciate any contribution to the Intel® Geti™ SDK, whether it's in the form of a
+We appreciate any contribution to the Geti™ SDK, whether it's in the form of a
 Pull Request, Feature Request or general comment/issue that you found. For feature
 requests and issues, please feel free to create a GitHub Issue in this repository.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <img
     width="120%"
     src="docs/geti-logo.png?raw=true"
-    alt="Intel® Geti™ enables anyone from domain experts to data scientists to rapidly develop production-ready AI models."
+    alt="Geti™ enables anyone from domain experts to data scientists to rapidly develop production-ready AI models."
   >
 </a>
 </p>
@@ -13,7 +13,7 @@
 <br>
 
 [![python](https://img.shields.io/badge/python-3.10%2B-green)]()
-![Intel Geti](https://img.shields.io/badge/Intel%C2%AE%20Geti%E2%84%A2-2.12-blue?link=https%3A%2F%2Fgeti.intel.com%2F)
+![Geti](https://img.shields.io/badge/Intel%C2%AE%20Geti%E2%84%A2-2.12-blue?link=https%3A%2F%2Fgeti.intel.com%2F)
 [![openvino](https://img.shields.io/badge/openvino-2025.2-purple)](https://github.com/openvinotoolkit/openvino)
 
 ![Pre-merge Tests Status](https://img.shields.io/github/actions/workflow/status/open-edge-platform/geti-sdk/pre-merge-tests.yml?label=pre-merge%20tests&link=https%3A%2F%2Fgithub.com%2Fopen-edge-platform%2Fgeti-sdk%2Factions%2Fworkflows%2Fpre-merge-tests.yml)
@@ -26,12 +26,12 @@
 
 # Geti SDK
 
-Geti SDK is a Python client for programmatically interacting with an [Intel® Geti™](https://github.com/open-edge-platform/geti) server via its [REST API](https://docs.geti.intel.com/docs/rest-api/openapi-specification).
+Geti SDK is a Python client for programmatically interacting with an [Geti™](https://github.com/open-edge-platform/geti) server via its [REST API](https://docs.geti.intel.com/docs/rest-api/openapi-specification).
 With Geti SDK, you can automate and streamline computer vision workflows, making it easy to manage datasets, train models, and deploy solutions directly from your Python environment.
 
 <!-- toc -->
 
-- [About Intel® Geti™](#what-is-intel-geti)
+- [About Geti™](#what-is-intel-geti)
 - [Install the SDK](#install-the-sdk)
   * [From PyPI](#from-pypi)
   * [From source](#from-source)
@@ -48,9 +48,9 @@ With Geti SDK, you can automate and streamline computer vision workflows, making
 
 <!-- tocstop -->
 
-### What is Intel® Geti™?
+### What is Geti™?
 
-[Intel® Geti™](https://github.com/open-edge-platform/geti) is an AI platform designed to help anyone build state-of-the-art computer vision models quickly and efficiently, even with minimal data.
+[Geti™](https://github.com/open-edge-platform/geti) is an AI platform designed to help anyone build state-of-the-art computer vision models quickly and efficiently, even with minimal data.
 It provides an end-to-end workflow for preparing, training, deploying, and running computer vision models at the edge. Geti™ supports the full AI model lifecycle, including dataset preparation, model training, and deployment of [OpenVINO™](https://docs.openvino.ai/)-optimized models.
 
 ### What can you do with Geti SDK?
@@ -68,7 +68,7 @@ With Geti SDK, you can:
 ### Tutorials and Examples
 
 The ['Code examples'](#code-examples) sections below contains short snippets that demonstrate
-how to perform several common tasks. This also shows how to configure the SDK to connect to your Intel® Geti™ server.
+how to perform several common tasks. This also shows how to configure the SDK to connect to your Geti™ server.
 
 For more comprehensive examples, see the [Jupyter notebooks](https://github.com/open-edge-platform/geti-sdk/tree/main/notebooks).
 These tutorials demonstrate how to use the SDK for various computer vision tasks and workflows, from basic project creation 
@@ -137,15 +137,15 @@ Follow these steps to install the SDK from a specific branch or commit:
 
 The package provides a main class `Geti` that can be used for the following use cases:
 
-### Connect to the Intel® Geti™ platform
+### Connect to the Geti™ platform
 
-To establish a connection between the SDK and the Intel® Geti™ platform, the `Geti` class needs to know the hostname or IP address for the server and requires authentication.
+To establish a connection between the SDK and the Geti™ platform, the `Geti` class needs to know the hostname or IP address for the server and requires authentication.
 
 #### Personal Access Token (Recommended)
 
 The recommended authentication method is the 'Personal Access Token'. To obtain a token:
 
-1. Open the Intel® Geti™ user interface in your browser
+1. Open the Geti™ user interface in your browser
 2. Click on the `User` menu in the top right corner
 3. Select `Personal access token` from the dropdown menu
 4. Follow the steps to create a token and copy the token value
@@ -366,9 +366,9 @@ although some advanced features may not be available yet due to technical and se
 - [x] **Deploy and benchmark models locally** - Export OpenVINO inference models, run full pipeline inference on local machines, and measure inference throughput on your hardware configurations
 - [x] **Download and upload datasets** - Export datasets to archives and import them to create new projects
 - [x] **Download and upload full projects** - Create complete backups of projects, including datasets, models and configurations, and restore them
-- [ ] **Upload trained models** - Intel® Geti™ does not allow to import external models
-- [ ] **Import datasets to existing projects** - currently, this feature is only available through the Intel® Geti™ UI and API
-- [ ] **Manage users and roles** - currently, this feature is only available through the Intel® Geti™ UI and API
+- [ ] **Upload trained models** - Geti™ does not allow to import external models
+- [ ] **Import datasets to existing projects** - currently, this feature is only available through the Geti™ UI and API
+- [ ] **Manage users and roles** - currently, this feature is only available through the Geti™ UI and API
 
 Are you looking for a specific feature that is not listed here?
 Please check if it is implemented by one of the clients in the [rest_clients](geti_sdk/rest_clients) module,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ with open(f"{root_path}/geti_sdk/_version.py", encoding="utf-8") as init_file:
 
 # -- Project information -----------------------------------------------------
 
-project = "Intel® Geti™ SDK"
+project = "Geti™ SDK"
 copyright = "2024 Intel Corporation"  # noqa: A001
 author = "Ludo Cornelissen"
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,17 +1,17 @@
-.. Intel® Geti™ SDK documentation master file
+.. Geti™ SDK documentation master file
 
-Intel® Geti™ SDK documentation
+Geti™ SDK documentation
 ======================================
 
-Welcome to the documentation for the Intel® Geti™ SDK! The purpose of this SDK is twofold:
+Welcome to the documentation for the Geti™ SDK! The purpose of this SDK is twofold:
 
-#. Provide an easy-to-use interface to the Intel® Geti™ platform, to manipulate
-   Intel® Geti™ projects and other entities or automate tasks on the platform. All
+#. Provide an easy-to-use interface to the Geti™ platform, to manipulate
+   Geti™ projects and other entities or automate tasks on the platform. All
    of this from a Python script or Jupyter notebook.
 
-#. Provide an API to deploy and run models trained on the Intel® Geti™ server on your local
+#. Provide an API to deploy and run models trained on the Geti™ server on your local
    machine. The SDK :py:mod:`~geti_sdk.deployment` module provides a straightforward
-   route to create a deployment for your Intel® Geti™ project, save it to a local disk and run
+   route to create a deployment for your Geti™ project, save it to a local disk and run
    it offline.
 
 This SDK includes various example scripts and Jupyter notebooks which illustrate a

--- a/geti_sdk/__init__.py
+++ b/geti_sdk/__init__.py
@@ -20,7 +20,7 @@ These pages contain the documentation for the main SDK class,
 :py:class:`~geti_sdk.geti.Geti`.
 
 The :py:class:`~geti_sdk.geti.Geti` class implements convenience
-methods for common operations that can be performed on the Intel® Geti™ cluster, such as
+methods for common operations that can be performed on the Geti™ cluster, such as
 creating a project from a pre-existing dataset, downloading or uploading a project,
 uploading an image and getting a prediction for it and creating a deployment for a
 project.
@@ -38,20 +38,20 @@ For example, to download a project, simply do:
    geti.download_project_data(project_name="dummy_project")
 
 The :py:class:`~geti_sdk.geti.Geti` class provides a high-level interface for
-import-export operations in Intel® Geti™ platform. Here is a list of these operations:
+import-export operations in Geti™ platform. Here is a list of these operations:
 * Project download
    :py:meth:`~geti_sdk.geti.Geti.download_project_data` method fetches the project data
    and creates a local Python object that supports a range of operations with the project.
 * Project upload
    :py:meth:`~geti_sdk.geti.Geti.upload_project_data` method uploads the project data
-   from a local Python object to the Intel® Geti™ platform.
+   from a local Python object to the Geti™ platform.
 * Batched project download and upload
    :py:meth:`~geti_sdk.geti.Geti.download_all_projects` and
    :py:meth:`~geti_sdk.geti.Geti.upload_all_projects` methods download and upload
    multiple projects at once.
 * Project export
    :py:meth:`~geti_sdk.geti.Geti.export_project` method exports the project snapshot
-   to a zip archive. The archive can be used to import the project to another or the same Intel® Geti™
+   to a zip archive. The archive can be used to import the project to another or the same Geti™
    instance.
 * Project import
    :py:meth:`~geti_sdk.geti.Geti.import_project` method imports the project from a zip archive.

--- a/geti_sdk/annotation_readers/__init__.py
+++ b/geti_sdk/annotation_readers/__init__.py
@@ -21,7 +21,7 @@ The `annotation_readers` package contains the
 base class, which provides an interface for implementing custom annotation readers.
 
 Annotation readers server to load annotation files in custom formats and convert them
-to Intel® Geti™ format, such that they can be uploaded to an Intel® Geti™ project.
+to Geti™ format, such that they can be uploaded to an Geti™ project.
 
 Module contents
 ---------------

--- a/geti_sdk/annotation_readers/base_annotation_reader.py
+++ b/geti_sdk/annotation_readers/base_annotation_reader.py
@@ -24,7 +24,7 @@ from geti_sdk.data_models.media import MediaInformation
 class AnnotationReader:
     """
     Base class for annotation reading, to handle loading and converting annotations
-    to Intel Geti format
+    to Geti format
     """
 
     def __init__(

--- a/geti_sdk/annotation_readers/directory_tree_annotation_reader.py
+++ b/geti_sdk/annotation_readers/directory_tree_annotation_reader.py
@@ -36,7 +36,7 @@ class DirectoryTreeAnnotationReader(AnnotationReader):
         that should not be considered as labels, but should be used to acquire the
         data. For example ['train', 'validation', 'test'] for a dataset that is split
         into three subsets.
-    :param task_type: TaskType for the task in the Intel® Geti™ platform to which the
+    :param task_type: TaskType for the task in the Geti™ platform to which the
         annotations should be uploaded
     """
 

--- a/geti_sdk/annotation_readers/geti_annotation_reader.py
+++ b/geti_sdk/annotation_readers/geti_annotation_reader.py
@@ -33,7 +33,7 @@ from .base_annotation_reader import AnnotationReader
 
 class GetiAnnotationReader(AnnotationReader):
     """
-    AnnotationReader for loading annotation files in Intel® Geti™ format.
+    AnnotationReader for loading annotation files in Geti™ format.
     """
 
     def __init__(
@@ -53,7 +53,7 @@ class GetiAnnotationReader(AnnotationReader):
             when reading annotation data. This can be used to filter the annotations
             for certain labels.
         :param anomaly_reduction: True to reduce all anomaly tasks to the single anomaly task.
-            This is done in accordance with the Intel Geti 2.5 Anomaly Reduction effort.
+            This is done in accordance with the Geti 2.5 Anomaly Reduction effort.
             All pixel level annotations are converted to full rectangles. All anomaly tasks
             are mapped to th new "Anomaly Detection" task wich corresponds to the old "Anomaly Classification".
         """
@@ -123,7 +123,7 @@ class GetiAnnotationReader(AnnotationReader):
             (e.g. width, height) about the media item to upload the annotation for
         :param preserve_shape_for_global_labels: False to convert shapes for global
             tasks to full rectangles (required for classification like tasks in
-            Intel® Geti™ projects), True to preserve such shapes. This parameter
+            Geti™ projects), True to preserve such shapes. This parameter
             should be:
 
              - False when uploading annotations to a single task project
@@ -154,8 +154,8 @@ class GetiAnnotationReader(AnnotationReader):
                     annotation_object.pop_label_by_name(label_name=label_dict["name"])
             new_annotations.append(annotation_object)
             if self.anomaly_reduction and annotation_object.labels[0].name.lower() == "anomalous":
-                # Part of anomaly task reduction in Intel Geti 2.5 -> all anomaly tasks combined into one.
-                # Intel Geti now only accepts full rectangles for anomaly tasks.
+                # Part of anomaly task reduction in Geti 2.5 -> all anomaly tasks combined into one.
+                # Geti now only accepts full rectangles for anomaly tasks.
                 new_annotations = [
                     Annotation(
                         labels=[annotation_object.labels[0]],
@@ -228,8 +228,8 @@ class GetiAnnotationReader(AnnotationReader):
             logging.info(
                 "Legacy annotation format detected. The annotations you are trying to "
                 "upload were most likely downloaded from a pre-production version of "
-                "the Intel Geti software. They will be converted to the latest "
-                "annotation format upon upload to the Intel Geti platform. "
+                "the Geti software. They will be converted to the latest "
+                "annotation format upon upload to the Geti platform. "
             )
             return True
         raise ValueError(

--- a/geti_sdk/benchmarking/__init__.py
+++ b/geti_sdk/benchmarking/__init__.py
@@ -18,7 +18,7 @@ Introduction
 
 The `benchmarking` package contains the
 :py:class:`~geti_sdk.benchmarking.benchmarker.Benchmarker` class, which provides
-methods for benchmarking models that are trained and deployed with Intel® Geti™.
+methods for benchmarking models that are trained and deployed with Geti™.
 
 For example, benchmarking local inference rates for your project can help in selecting
 the model architecture to use for your project, or in assessing the performance of the

--- a/geti_sdk/benchmarking/benchmarker.py
+++ b/geti_sdk/benchmarking/benchmarker.py
@@ -67,7 +67,7 @@ class Benchmarker:
         framerates for different model architectures and precision levels for the
         specified project.
 
-        The Benchmarker will fetch models from Intel Geti and measure the
+        The Benchmarker will fetch models from Geti and measure the
         throughput for local inference for these models. It requires an existing Geti
         Project to work. The project does not need to be trained yet, but must have
         sufficient annotations to be able to start training.
@@ -112,7 +112,7 @@ class Benchmarker:
         self.geti = geti
         # Update project object to get the latest project details
         self.project = self.geti.get_project(project_id=project.id)
-        logging.info(f"Setting up Benchmarker for Intel® Geti™ project `{self.project.name}`.")
+        logging.info(f"Setting up Benchmarker for Geti™ project `{self.project.name}`.")
         self._is_single_task = len(self.project.get_trainable_tasks()) == 1
         if precision_levels is None:
             precision_levels = ["FP32", "FP16"]

--- a/geti_sdk/data_models/algorithms.py
+++ b/geti_sdk/data_models/algorithms.py
@@ -28,7 +28,7 @@ from .utils import attr_value_serializer, remove_null_fields
 @attr.define
 class LegacyAlgorithm:
     """
-    Representation of a supported algorithm on the Intel® Geti™ platform.
+    Representation of a supported algorithm on the Geti™ platform.
     """
 
     model_size: str

--- a/geti_sdk/data_models/annotations.py
+++ b/geti_sdk/data_models/annotations.py
@@ -31,7 +31,7 @@ from geti_sdk.data_models.utils import deidentify, str_to_datetime
 @attr.define
 class Annotation:
     """
-    Representation of a single annotation for a media item on the Intel® Geti™ platform.
+    Representation of a single annotation for a media item on the Geti™ platform.
 
     :var labels: List of labels belonging to the annotation
     :var modified: Date and time of the last modification made to this annotation

--- a/geti_sdk/data_models/code_deployment_info.py
+++ b/geti_sdk/data_models/code_deployment_info.py
@@ -54,7 +54,7 @@ class DeploymentModelIdentifier:
 @attr.define()
 class CodeDeploymentInformation:
     """
-    Class containing information pertaining to the deployment of an Intel® Geti™
+    Class containing information pertaining to the deployment of an Geti™
     project.
 
     :var id: Unique ID of the code deployment

--- a/geti_sdk/data_models/configuration_identifiers.py
+++ b/geti_sdk/data_models/configuration_identifiers.py
@@ -24,7 +24,7 @@ from geti_sdk.data_models.utils import attr_value_serializer, str_to_enum_conver
 @attr.define
 class EntityIdentifier:
     """
-    Identifying information for a configurable entity on the Intel® Geti™ platform,
+    Identifying information for a configurable entity on the Geti™ platform,
     as returned by the /configuration endpoint.
 
     :var workspace_id: ID of the workspace to which the entity belongs
@@ -48,7 +48,7 @@ class EntityIdentifier:
 @attr.define
 class HyperParameterGroupIdentifier(EntityIdentifier):
     """
-    Identifying information for a HyperParameterGroup on the Intel® Geti™ platform,
+    Identifying information for a HyperParameterGroup on the Geti™ platform,
     as returned by the /configuration endpoint.
 
     :var model_storage_id: ID of the model storage to which the hyper parameter group
@@ -79,7 +79,7 @@ class HyperParameterGroupIdentifier(EntityIdentifier):
 @attr.define
 class ComponentEntityIdentifier(EntityIdentifier):
     """
-    Identifying information for a configurable Component on the Intel® Geti™ platform,
+    Identifying information for a configurable Component on the Geti™ platform,
     as returned by the /configuration endpoint.
 
     :var component: Name of the component

--- a/geti_sdk/data_models/containers/algorithm_list.py
+++ b/geti_sdk/data_models/containers/algorithm_list.py
@@ -36,7 +36,7 @@ DEFAULT_ALGORITHMS = {
 
 class AlgorithmList(UserList):
     """
-    A list containing the algorithms supported in Intel® Geti™.
+    A list containing the algorithms supported in Geti™.
     """
 
     def __init__(self, data: Sequence[Algorithm] | None = None):
@@ -48,11 +48,11 @@ class AlgorithmList(UserList):
     def from_rest(rest_input: dict[str, Any], geti_version: GetiVersion) -> "AlgorithmList":
         """
         Create an AlgorithmList from the response of the /supported_algorithms REST
-        endpoint in Intel® Geti™.
+        endpoint in Geti™.
 
         :param rest_input: Dictionary retrieved from the /supported_algorithms REST endpoint
-        :param geti_version: Version of Intel® Geti™ platform
-        :return: AlgorithmList holding the information related to the supported algorithms in Intel® Geti™
+        :param geti_version: Version of Geti™ platform
+        :return: AlgorithmList holding the information related to the supported algorithms in Geti™
         """
         algorithm_list = AlgorithmList([])
         if "items" in rest_input:

--- a/geti_sdk/data_models/containers/label_list.py
+++ b/geti_sdk/data_models/containers/label_list.py
@@ -23,7 +23,7 @@ from geti_sdk.utils.serialization_helpers import deserialize_dictionary
 
 class LabelList(UserList):
     """
-    A list containing labels for an Intel® Geti™ inference model.
+    A list containing labels for an Geti™ inference model.
     """
 
     def __init__(self, data: Sequence[Label] | None = None):

--- a/geti_sdk/data_models/containers/media_list.py
+++ b/geti_sdk/data_models/containers/media_list.py
@@ -26,7 +26,7 @@ MediaTypeVar = TypeVar("MediaTypeVar", Image, Video, VideoFrame)
 
 class MediaList(UserList, Generic[MediaTypeVar]):
     """
-    A list containing Intel® Geti™ media entities
+    A list containing Geti™ media entities
     """
 
     @property
@@ -74,9 +74,9 @@ class MediaList(UserList, Generic[MediaTypeVar]):
     def from_rest_list(rest_input: list[dict[str, Any]], media_type: type[MediaTypeVar]) -> MediaList[MediaTypeVar]:
         """
         Create a MediaList instance from a list of media entities obtained from the
-        Intel® Geti™ /media endpoints.
+        Geti™ /media endpoints.
 
-        :param rest_input: List of dictionaries representing media entities in Intel® Geti™
+        :param rest_input: List of dictionaries representing media entities in Geti™
         :param media_type: Image or Video, type of the media entities that are to be
             converted.
 

--- a/geti_sdk/data_models/credit_system.py
+++ b/geti_sdk/data_models/credit_system.py
@@ -34,7 +34,7 @@ from geti_sdk.data_models.utils import (
 @attr.define
 class CreditBalance:
     """
-    Representation of the Credit Balance in Intel Geti
+    Representation of the Credit Balance in Geti
     """
 
     incoming: int
@@ -45,7 +45,7 @@ class CreditBalance:
 @attr.define
 class CreditAccount:
     """
-    Representation of the Credit Account in Intel Geti
+    Representation of the Credit Account in Geti
     """
 
     _identifier_fields = [
@@ -96,7 +96,7 @@ class CreditAccount:
 @attr.define
 class Subscription:
     """
-    Representation of the Subscription in Intel Geti
+    Representation of the Subscription in Geti
     """
 
     _identifier_fields = [

--- a/geti_sdk/data_models/dataset.py
+++ b/geti_sdk/data_models/dataset.py
@@ -28,7 +28,7 @@ from geti_sdk.data_models.utils import (
 @attr.define
 class Dataset:
     """
-    Representation of a dataset for a project in Intel® Geti™.
+    Representation of a dataset for a project in Geti™.
 
     :var id: Unique database ID of the dataset
     :var name: name of the dataset

--- a/geti_sdk/data_models/enums/annotation_kind.py
+++ b/geti_sdk/data_models/enums/annotation_kind.py
@@ -17,7 +17,7 @@ from enum import Enum
 
 class AnnotationKind(Enum):
     """
-    Enum representing the different kind of annotation scenes on the Intel® Geti™
+    Enum representing the different kind of annotation scenes on the Geti™
     platform.
     """
 

--- a/geti_sdk/data_models/enums/annotation_state.py
+++ b/geti_sdk/data_models/enums/annotation_state.py
@@ -18,7 +18,7 @@ from enum import Enum
 class AnnotationState(Enum):
     """
     Enum representing the different annotation statuses for media items within an
-    Intel® Geti™ project.
+    Geti™ project.
     """
 
     TO_REVISIT = "to_revisit"

--- a/geti_sdk/data_models/enums/configuration_enums.py
+++ b/geti_sdk/data_models/enums/configuration_enums.py
@@ -17,7 +17,7 @@ from enum import Enum
 
 class ConfigurationEntityType(Enum):
     """
-    Enum representing the different configuration types on the Intel® Geti™ platform.
+    Enum representing the different configuration types on the Geti™ platform.
     """
 
     HYPER_PARAMETER_GROUP = "HYPER_PARAMETER_GROUP"
@@ -33,7 +33,7 @@ class ConfigurationEntityType(Enum):
 class ParameterDataType(Enum):
     """
     Enum representing the different data types for configurable parameters on the
-    Intel® Geti™ platform.
+    Geti™ platform.
     """
 
     BOOLEAN = "boolean"
@@ -51,7 +51,7 @@ class ParameterDataType(Enum):
 class ParameterInputType(Enum):
     """
     Enum representing the different input types for configurable parameters on the
-    Intel® Geti™ platform.
+    Geti™ platform.
     """
 
     INPUT = "input"
@@ -67,7 +67,7 @@ class ParameterInputType(Enum):
 class ConfigurableParameterType(Enum):
     """
     Enum representing the different types of configurable parameters on the
-    Intel® Geti™ platform.
+    Geti™ platform.
     """
 
     CONFIGURABLE_PARAMETERS = "CONFIGURABLE_PARAMETERS"

--- a/geti_sdk/data_models/enums/dataset_format.py
+++ b/geti_sdk/data_models/enums/dataset_format.py
@@ -18,7 +18,7 @@ from enum import Enum
 class DatasetFormat(Enum):
     """
     Enum representing the different annotation formats for datasets within an
-    Intel® Geti™ platform.
+    Geti™ platform.
     """
 
     COCO = "coco"

--- a/geti_sdk/data_models/enums/deployment_state.py
+++ b/geti_sdk/data_models/enums/deployment_state.py
@@ -16,7 +16,7 @@ from enum import Enum
 
 class DeploymentState(Enum):
     """
-    Enum representing the status of a deployment creation process for an Intel® Geti™
+    Enum representing the status of a deployment creation process for an Geti™
     project.
     """
 

--- a/geti_sdk/data_models/enums/domain.py
+++ b/geti_sdk/data_models/enums/domain.py
@@ -19,7 +19,7 @@ from geti_sdk.data_models.enums.task_type import TaskType
 
 class Domain(Enum):
     """
-    Enum representing the different task domains in Intel® Geti™ projects.
+    Enum representing the different task domains in Geti™ projects.
     """
 
     DETECTION = "DETECTION"

--- a/geti_sdk/data_models/enums/job_state.py
+++ b/geti_sdk/data_models/enums/job_state.py
@@ -17,7 +17,7 @@ from enum import Enum
 
 class JobState(Enum):
     """
-    Enum representing the state of a job on the Intel® Geti™ server.
+    Enum representing the state of a job on the Geti™ server.
     """
 
     IDLE = "idle"

--- a/geti_sdk/data_models/enums/job_type.py
+++ b/geti_sdk/data_models/enums/job_type.py
@@ -17,7 +17,7 @@ from enum import Enum
 
 class JobType(Enum):
     """
-    Enum representing the type of a job on the Intel® Geti™ cluster.
+    Enum representing the type of a job on the Geti™ cluster.
     """
 
     UNDEFINED = "undefined"

--- a/geti_sdk/data_models/enums/optimization_type.py
+++ b/geti_sdk/data_models/enums/optimization_type.py
@@ -17,7 +17,7 @@ from enum import Enum
 
 class OptimizationType(Enum):
     """
-    Enum representing the optimization type for an OptimizedModel in Intel® Geti™.
+    Enum representing the optimization type for an OptimizedModel in Geti™.
     """
 
     NNCF = "NNCF"

--- a/geti_sdk/data_models/enums/prediction_mode.py
+++ b/geti_sdk/data_models/enums/prediction_mode.py
@@ -17,7 +17,7 @@ from enum import Enum
 
 class PredictionMode(Enum):
     """
-    Enum representing the mode used to generate predictions on the Intel® Geti™
+    Enum representing the mode used to generate predictions on the Geti™
     platform.
     """
 

--- a/geti_sdk/data_models/enums/shape_type.py
+++ b/geti_sdk/data_models/enums/shape_type.py
@@ -17,7 +17,7 @@ from enum import Enum
 
 class ShapeType(Enum):
     """
-    Enum representing the types of shapes available for annotations on the Intel® Geti™
+    Enum representing the types of shapes available for annotations on the Geti™
     platform.
     """
 

--- a/geti_sdk/data_models/enums/subscription_status.py
+++ b/geti_sdk/data_models/enums/subscription_status.py
@@ -17,7 +17,7 @@ from enum import Enum
 
 class SubscriptionStatus(Enum):
     """
-    Enum representing the status of a subscription on the Intel® Geti™ platform.
+    Enum representing the status of a subscription on the Geti™ platform.
     """
 
     ACTIVE = "ACTIVE"

--- a/geti_sdk/data_models/enums/subset_purpose.py
+++ b/geti_sdk/data_models/enums/subset_purpose.py
@@ -17,7 +17,7 @@ from enum import Enum
 
 class SubsetPurpose(Enum):
     """
-    Enum representing the purpose of a subset of a dataset on the Intel® Geti™ platform.
+    Enum representing the purpose of a subset of a dataset on the Geti™ platform.
     """
 
     TRAINING = "training"

--- a/geti_sdk/data_models/enums/task_type.py
+++ b/geti_sdk/data_models/enums/task_type.py
@@ -17,7 +17,7 @@ from enum import Enum
 
 class TaskType(Enum):
     """
-    Enum representing the different task types in Intel® Geti™ projects.
+    Enum representing the different task types in Geti™ projects.
     """
 
     DETECTION = "detection"

--- a/geti_sdk/data_models/job.py
+++ b/geti_sdk/data_models/job.py
@@ -33,7 +33,7 @@ from geti_sdk.platform_versions import GetiVersion
 @attr.define(slots=False)
 class JobStatus(StatusSummary):
     """
-    Current status of a job on the Intel® Geti™ server.
+    Current status of a job on the Geti™ server.
 
     :var state: Current state of the job
     """
@@ -46,7 +46,7 @@ class JobStatus(StatusSummary):
         Create a JobStatus object from a dictionary.
 
         :param status_dict: Dictionary representing a status, as returned by the
-            Intel® Geti™ /status and /jobs endpoints
+            Geti™ /status and /jobs endpoints
         :return: JobStatus object holding the status data contained in `status_dict`
         """
         return cls(**status_dict)
@@ -55,7 +55,7 @@ class JobStatus(StatusSummary):
 @attr.define
 class TaskMetadata:
     """
-    Metadata related to a task on the Intel® Geti™ cluster.
+    Metadata related to a task on the Geti™ cluster.
 
     :var name: Name of the task
     :var model_template_id: Identifier of the model template used by the task
@@ -200,7 +200,7 @@ class JobMetadata:
 @attr.define
 class JobCancellationInfo:
     """
-    Information relating to the cancellation of a Job in Intel Geti
+    Information relating to the cancellation of a Job in Geti
 
     :var is_cancelled: True if the job is cancelled, False otherwise
     :var user_uid: Unique ID of the User who cancelled the Job
@@ -216,7 +216,7 @@ class JobCancellationInfo:
 @attr.define
 class JobCost:
     """
-    Information relating to the cost of a Job in Intel Geti.
+    Information relating to the cost of a Job in Geti.
     """
 
     requests: list
@@ -443,9 +443,9 @@ class Job:
     @property
     def geti_version(self) -> GetiVersion:
         """
-        Return the version of the Intel Geti instance from which the job originates.
+        Return the version of the Geti instance from which the job originates.
 
-        :return: Version of the Intel Geti instance from which the job originates
+        :return: Version of the Geti instance from which the job originates
         """
         if self._geti_version is None:
             raise ValueError(f"Geti version for job {self} is unknown, it was never set.")
@@ -454,8 +454,8 @@ class Job:
     @geti_version.setter
     def geti_version(self, geti_version: GetiVersion):
         """
-        Set the version of the Intel Geti instance for the job.
+        Set the version of the Geti instance for the job.
 
-        :param geti_version: Version of the Intel Geti instance from which the job originates
+        :param geti_version: Version of the Geti instance from which the job originates
         """
         self._geti_version = geti_version

--- a/geti_sdk/data_models/media.py
+++ b/geti_sdk/data_models/media.py
@@ -44,7 +44,7 @@ from .utils import (
 @attr.define
 class MediaInformation:
     """
-    Basic information about a media item in Intel® Geti™.
+    Basic information about a media item in Geti™.
 
     :var display_url: URL that can be used to download the full size media entity
     :var height: Height of the media entity, in pixels
@@ -62,7 +62,7 @@ class MediaInformation:
 @attr.define
 class VideoInformation(MediaInformation):
     """
-    Basic information about a video entity in Intel® Geti™.
+    Basic information about a video entity in Geti™.
 
     :var duration: Duration of the video
     :var frame_count: Total number of frames in the video
@@ -79,7 +79,7 @@ class VideoInformation(MediaInformation):
 @attr.define
 class ImageInformation(MediaInformation):
     """
-    Basic information about an image entity in Intel® Geti™
+    Basic information about an image entity in Geti™
     """
 
     pass
@@ -88,7 +88,7 @@ class ImageInformation(MediaInformation):
 @attr.define
 class VideoFrameInformation(MediaInformation):
     """
-    Basic information about a video frame in Intel® Geti™.
+    Basic information about a video frame in Geti™.
     """
 
     frame_index: int = attr.ib(kw_only=True)
@@ -98,7 +98,7 @@ class VideoFrameInformation(MediaInformation):
 @attr.define
 class MediaPreprocessing:
     """
-    Basic information about a media preprocessing in Intel® Geti™.
+    Basic information about a media preprocessing in Geti™.
     """
 
     status: str = attr.ib(kw_only=True)
@@ -108,7 +108,7 @@ class MediaPreprocessing:
 @attr.define
 class MediaItem:
     """
-    Representation of a media entity in Intel® Geti™.
+    Representation of a media entity in Geti™.
 
     :var id: Unique database ID of the media entity
     :var name: Filename of the media entity
@@ -138,7 +138,7 @@ class MediaItem:
     def download_url(self) -> str:
         """
         Return the URL that can be used to download the full size media entity from the
-        Intel® Geti™ server.
+        Geti™ server.
 
         :return: URL at which the media entity can be downloaded
         """
@@ -185,7 +185,7 @@ class MediaItem:
         objects, this method will return a path-like string, pointing to the video
         on the local disk.
 
-        :param session: REST session to the Intel® Geti™ server on which the MediaItem
+        :param session: REST session to the Geti™ server on which the MediaItem
             lives
         :raises ValueError: If the cache is empty and no data can be downloaded
             from the cluster
@@ -215,7 +215,7 @@ class MediaItem:
 @attr.define(slots=False)
 class Image(MediaItem):
     """
-    Representation of an image in Intel® Geti™.
+    Representation of an image in Geti™.
 
     :var media_information: Container holding basic information such as width and
             height about the image entity
@@ -248,7 +248,7 @@ class Image(MediaItem):
 
         NOTE: The pixel data will be returned in BGR channel order
 
-        :param session: REST session to the Intel® Geti™ server on which the Image lives
+        :param session: REST session to the Geti™ server on which the Image lives
         :raises ValueError: If the cache is empty and no data can be downloaded
             from the cluster
         :return: Numpy.ndarray holding the pixel data for this Image.
@@ -259,7 +259,7 @@ class Image(MediaItem):
                 self._data = numpy_from_buffer(response.content)
             else:
                 raise ValueError(
-                    f"Unable to retrieve data for image {self}, received response {response} from Intel® Geti™ server."
+                    f"Unable to retrieve data for image {self}, received response {response} from Geti™ server."
                 )
         return self._data
 
@@ -278,7 +278,7 @@ class Image(MediaItem):
 @attr.define(slots=False)
 class VideoAnnotationStatistics:
     """
-    Annotation statistics for a video in Intel® Geti™.
+    Annotation statistics for a video in Geti™.
 
     :var annotated: Number of frames in the video that have been fully annotated
     :var partially_annotated: Number of frames in the video that have been partially
@@ -294,7 +294,7 @@ class VideoAnnotationStatistics:
 @attr.define(slots=False)
 class Video(MediaItem):
     """
-    Representation of a video in Intel® Geti™.
+    Representation of a video in Geti™.
 
     :var media_information: Container holding basic information such as width,
             height and duration about the video entity
@@ -323,7 +323,7 @@ class Video(MediaItem):
 
     def get_data(self, session: GetiSession) -> str:
         """
-        Get the video data from the Intel® Geti™ server. Calling this method will
+        Get the video data from the Geti™ server. Calling this method will
         download the video data to a temporary file, and returns the path to file.
 
         :param session: GetiSession object pointing to the instance from which the video
@@ -340,7 +340,7 @@ class Video(MediaItem):
                 self._needs_tempfile_deletion = True
             else:
                 raise ValueError(
-                    f"Unable to retrieve data for image {self}, received response {response} from Intel® Geti™ server."
+                    f"Unable to retrieve data for image {self}, received response {response} from Geti™ server."
                 )
         return self._data
 
@@ -397,7 +397,7 @@ class Video(MediaItem):
 @attr.define(slots=False)
 class VideoFrame(MediaItem):
     """
-    Representation of a video frame in Intel® Geti™.
+    Representation of a video frame in Geti™.
 
     :var media_information: Container holding basic information such as width and
             height about the VideoFrame entity
@@ -474,7 +474,7 @@ class VideoFrame(MediaItem):
         is empty, it will download the data using the provided session. Otherwise it
         will return the cached data directly
 
-        :param session: REST session to the Intel® Geti™ server on which the
+        :param session: REST session to the Geti™ server on which the
             VideoFrame lives
         :raises ValueError: If the cache is empty and no data can be downloaded
             from the cluster
@@ -486,6 +486,6 @@ class VideoFrame(MediaItem):
                 self._data = numpy_from_buffer(response.content)
             else:
                 raise ValueError(
-                    f"Unable to retrieve data for image {self}, received response {response} from Intel® Geti™ server."
+                    f"Unable to retrieve data for image {self}, received response {response} from Geti™ server."
                 )
         return self._data

--- a/geti_sdk/data_models/media_identifiers.py
+++ b/geti_sdk/data_models/media_identifiers.py
@@ -22,7 +22,7 @@ from geti_sdk.data_models.utils import attr_value_serializer, str_to_media_type
 @attr.define
 class MediaIdentifier:
     """
-    Representation of media identification data as output by the Intel® Geti™
+    Representation of media identification data as output by the Geti™
     /annotations REST endpoints.
 
     :var type: Type of the media to which the annotation belongs
@@ -42,8 +42,8 @@ class MediaIdentifier:
 @attr.define
 class ImageIdentifier(MediaIdentifier):
     """
-    Representation of image identification data used by the Intel® Geti™ /annotations
-    endpoints. This object uniquely identifies an Image on the Intel® Geti™ server.
+    Representation of image identification data used by the Geti™ /annotations
+    endpoints. This object uniquely identifies an Image on the Geti™ server.
 
     :var image_id: unique database ID of the image
     """
@@ -56,9 +56,9 @@ class ImageIdentifier(MediaIdentifier):
 @attr.define
 class VideoFrameIdentifier(MediaIdentifier):
     """
-    Representation of video frame identification data used by the Intel® Geti™
+    Representation of video frame identification data used by the Geti™
     /annotations endpoints. This object uniquely identifies a VideoFrame on the
-    Intel® Geti™ server.
+    Geti™ server.
 
     :var frame_index: Index of the video frame in the full video
     :var video_id: unique database ID of the video to which the frame belongs
@@ -75,8 +75,8 @@ class VideoFrameIdentifier(MediaIdentifier):
 @attr.define
 class VideoIdentifier(MediaIdentifier):
     """
-    Representation of video identification data used by the Intel® Geti™ /annotations
-    endpoints. This object uniquely identifiers a Video on the Intel® Geti™ server.
+    Representation of video identification data used by the Geti™ /annotations
+    endpoints. This object uniquely identifiers a Video on the Geti™ server.
 
     :var video_id: unique database ID of the video
     """

--- a/geti_sdk/data_models/model.py
+++ b/geti_sdk/data_models/model.py
@@ -37,7 +37,7 @@ from .performance import Performance
 @attr.define
 class OptimizationCapabilities:
     """
-    Representation of the various model optimization capabilities in Intel Geti.
+    Representation of the various model optimization capabilities in Geti.
     """
 
     is_nncf_supported: bool
@@ -71,7 +71,7 @@ class TrainingFramework:
 @attr.define
 class OptimizationConfigurationParameter:
     """
-    Representation of a parameter for model optimization in Intel Geti.
+    Representation of a parameter for model optimization in Geti.
     """
 
     name: str
@@ -81,7 +81,7 @@ class OptimizationConfigurationParameter:
 @attr.define(slots=False)
 class BaseModel:
     """
-    Representation of the basic information for a Model or OptimizedModel in Intel Geti
+    Representation of the basic information for a Model or OptimizedModel in Geti
     """
 
     _identifier_fields: ClassVar[str] = [
@@ -103,10 +103,10 @@ class BaseModel:
     previous_trained_revision_id: str | None = None
     performance: Performance | None = None
     id: str | None = attr.field(default=None)
-    label_schema_in_sync: bool | None = attr.field(default=None)  # Added in Intel Geti 1.1
-    total_disk_size: int | None = None  # Added in Intel Geti 2.3
-    training_framework: TrainingFramework | None = None  # Added in Intel Geti 2.5
-    learning_approach: str | None = None  # Added in Intel Geti v2.6
+    label_schema_in_sync: bool | None = attr.field(default=None)  # Added in Geti 1.1
+    total_disk_size: int | None = None  # Added in Geti 2.3
+    training_framework: TrainingFramework | None = None  # Added in Geti 2.5
+    learning_approach: str | None = None  # Added in Geti v2.6
 
     def __attrs_post_init__(self):
         """
@@ -141,7 +141,7 @@ class BaseModel:
         model, etc., if available.
 
         :return: base url at which the model can be addressed. The url is defined
-            relative to the ip address or hostname of the Intel® Geti™ server
+            relative to the ip address or hostname of the Geti™ server
         """
         if self._base_url is not None:
             return self._base_url
@@ -207,7 +207,7 @@ class BaseModel:
 @attr.define(slots=False)
 class OptimizedModel(BaseModel):
     """
-    Representation of an OptimizedModel in Intel® Geti™. An optimized model is a trained model
+    Representation of an OptimizedModel in Geti™. An optimized model is a trained model
     that has been converted OpenVINO representation. This conversion may involve weight
     quantization, filter pruning, or other optimization techniques supported by
     OpenVINO.
@@ -220,15 +220,15 @@ class OptimizedModel(BaseModel):
     version: int | None = attr.field(kw_only=True, default=None)
     configurations: list[OptimizationConfigurationParameter] | None = attr.field(
         kw_only=True, default=None
-    )  # Added in Intel Geti v1.4
-    model_format: str | None = None  # Added in Intel Geti v1.5
-    has_xai_head: bool = False  # Added in Intel Geti v1.5
+    )  # Added in Geti v1.4
+    model_format: str | None = None  # Added in Geti v1.5
+    has_xai_head: bool = False  # Added in Geti v1.5
 
 
 @attr.define(slots=False)
 class Model(BaseModel):
     """
-    Representation of a trained Model in Intel® Geti™.
+    Representation of a trained Model in Geti™.
     """
 
     architecture: str = attr.field(kw_only=True)

--- a/geti_sdk/data_models/model_group.py
+++ b/geti_sdk/data_models/model_group.py
@@ -26,7 +26,7 @@ from geti_sdk.data_models.utils import str_to_datetime
 @attr.define
 class ModelSummary:
     """
-    Representation of a Model on the Intel® Geti™ platform, containing only the
+    Representation of a Model on the Geti™ platform, containing only the
     minimal information about the model.
 
     :var name: Name of the model
@@ -62,7 +62,7 @@ class ModelSummary:
 @attr.define(slots=False)
 class ModelGroup:
     """
-    Representation of a ModelGroup on the Intel® Geti™ server. A model group is a
+    Representation of a ModelGroup on the Geti™ server. A model group is a
     collection of models that all share the same neural network architecture, but may
     have been trained with different training datasets or hyper parameters.
     """
@@ -142,7 +142,7 @@ class ModelGroup:
         """
         Return the details for the algorithm corresponding to the ModelGroup
         This property will return None unless the `get_algorithm_details` method is
-        called to retrieve the algorithm information from the Intel® Geti™ server
+        called to retrieve the algorithm information from the Geti™ server
 
         :return: Algorithm details, if available
         """

--- a/geti_sdk/data_models/performance.py
+++ b/geti_sdk/data_models/performance.py
@@ -32,7 +32,7 @@ class Score:
 @attr.define()
 class TaskPerformance:
     """
-    Task Performance metrics in Intel® Geti™.
+    Task Performance metrics in Geti™.
 
     :var task_id: Unique ID of the task to which this Performance metric
         applies.
@@ -52,7 +52,7 @@ class TaskPerformance:
 @attr.define()
 class Performance:
     """
-    Performance metrics for a project or model in Intel® Geti™.
+    Performance metrics for a project or model in Geti™.
 
     :var score: Overall score of the project or model
     :var local_score: Accuracy of the model or project with respect to object

--- a/geti_sdk/data_models/predictions.py
+++ b/geti_sdk/data_models/predictions.py
@@ -81,8 +81,7 @@ class ResultMedium:
                 self.data = response.content
             else:
                 raise ValueError(
-                    f"Unable to retrieve data for result medium {self}, received "
-                    f"response {response} from Geti™ server."
+                    f"Unable to retrieve data for result medium {self}, received response {response} from Geti™ server."
                 )
         return self.data
 

--- a/geti_sdk/data_models/predictions.py
+++ b/geti_sdk/data_models/predictions.py
@@ -34,7 +34,7 @@ from geti_sdk.http_session import GetiSession
 @attr.define
 class ResultMedium:
     """
-    Representation of a single result medium in Intel® Geti™.
+    Representation of a single result medium in Geti™.
 
     :var name: Name of the result medium option
     :var type: Type of the result medium represented by this object
@@ -71,7 +71,7 @@ class ResultMedium:
         """
         Download the data belonging to this ResultMedium object.
 
-        :param session: REST session to the Intel® Geti™ server from which this ResultMedium
+        :param session: REST session to the Geti™ server from which this ResultMedium
             was generated
         :return: bytes object holding the data, if any is found
         """
@@ -82,7 +82,7 @@ class ResultMedium:
             else:
                 raise ValueError(
                     f"Unable to retrieve data for result medium {self}, received "
-                    f"response {response} from Intel® Geti™ server."
+                    f"response {response} from Geti™ server."
                 )
         return self.data
 
@@ -99,10 +99,10 @@ class ResultMedium:
 @attr.define
 class Prediction(AnnotationScene):
     """
-    Representation of the model predictions for a certain media entity in Intel® Geti™.
+    Representation of the model predictions for a certain media entity in Geti™.
 
     :var annotations: List of predictions belonging to the media entity
-    :var id: unique database ID of the Prediction in Intel® Geti™
+    :var id: unique database ID of the Prediction in Geti™
     :var kind: Kind of prediction (Annotation or Prediction)
     :var media_identifier: Identifier of the media entity to which this Prediction
         applies
@@ -158,7 +158,7 @@ class Prediction(AnnotationScene):
         """
         Download the data for all result media belonging to this prediction.
 
-        :param session: REST session to the Intel® Geti™ server from which this Prediction
+        :param session: REST session to the Geti™ server from which this Prediction
             was generated
         :return: List of result media, that have their data downloaded from the cluster
         """

--- a/geti_sdk/data_models/project.py
+++ b/geti_sdk/data_models/project.py
@@ -152,7 +152,7 @@ class Pipeline:
 @attr.define
 class Project:
     """
-    Representation of a project in Intel® Geti™.
+    Representation of a project in Geti™.
 
     :var id: Unique database ID of the project
     :var name: Name of the project

--- a/geti_sdk/data_models/shapes.py
+++ b/geti_sdk/data_models/shapes.py
@@ -24,7 +24,7 @@ from geti_sdk.data_models.enums import ShapeType
 from geti_sdk.data_models.utils import round_to_n_digits, str_to_shape_type
 
 # N_DIGITS_TO_ROUND_TO determines how pixel coordinates will be rounded when they are
-# passed from the Intel® Geti™ REST API. The Intel® Geti™ server itself rounds some
+# passed from the Geti™ REST API. The Geti™ server itself rounds some
 # coordinates to 4 digits, but not all. Here we round all coordinates for internal
 # consistency
 N_DIGITS_TO_ROUND_TO = 0
@@ -34,7 +34,7 @@ coordinate_converter = round_to_n_digits(N_DIGITS_TO_ROUND_TO)
 @attr.define(slots=False)
 class Shape:
     """
-    Representation of a shape in on the Intel® Geti™ platform.
+    Representation of a shape in on the Geti™ platform.
 
     :var type: Type of the shape
     """
@@ -91,7 +91,7 @@ class Shape:
 @attr.define(slots=False)
 class Rectangle(Shape):
     """
-    Representation of a Rectangle on the Intel® Geti™ platform, as used in the
+    Representation of a Rectangle on the Geti™ platform, as used in the
     /annotations REST endpoints.
 
     NOTE: All coordinates and dimensions are given in pixels
@@ -203,7 +203,7 @@ class Rectangle(Shape):
 @attr.define(slots=False)
 class Ellipse(Shape):
     """
-    Representation of an Ellipse on the Intel® Geti™ platform, as used in the
+    Representation of an Ellipse on the Geti™ platform, as used in the
     /annotations REST endpoints.
 
     NOTE: All coordinates and dimensions are given in pixels
@@ -303,7 +303,7 @@ class Ellipse(Shape):
 class Point:
     """
     Representation of a point on a 2D coordinate system. Used to define Polygons on
-    the Intel® Geti™ platform.
+    the Geti™ platform.
 
     NOTE: All coordinates are defined in pixels
 
@@ -326,7 +326,7 @@ class Point:
 @attr.define(slots=False)
 class Polygon(Shape):
     """
-    Representation of a polygon on the Intel® Geti™ platform, as used in the
+    Representation of a polygon on the Geti™ platform, as used in the
     /annotations REST endpoints.
 
     :var points: List of Points that make up the polygon
@@ -456,7 +456,7 @@ class Polygon(Shape):
 @attr.define(slots=False)
 class RotatedRectangle(Shape):
     """
-    Representation of a RotatedRectangle on the Intel® Geti™ platform, as used in the
+    Representation of a RotatedRectangle on the Geti™ platform, as used in the
     /annotations REST endpoints.
 
     NOTE: All coordinates and dimensions are specified in pixels
@@ -696,7 +696,7 @@ class RotatedRectangle(Shape):
 @attr.define(slots=False)
 class Keypoint(Shape):
     """
-    Representation of a Keypoint on the Intel® Geti™ platform, as used in the
+    Representation of a Keypoint on the Geti™ platform, as used in the
     /annotations REST endpoints.
 
     NOTE: All coordinates and dimensions are given in pixels

--- a/geti_sdk/data_models/task_annotation_state.py
+++ b/geti_sdk/data_models/task_annotation_state.py
@@ -22,7 +22,7 @@ from geti_sdk.data_models.utils import str_to_enum_converter_by_name_or_value
 class TaskAnnotationState:
     """
     Representation of the state of an annotation for a particular task in an
-    Intel® Geti™ project.
+    Geti™ project.
     """
 
     task_id: str

--- a/geti_sdk/data_models/test_result.py
+++ b/geti_sdk/data_models/test_result.py
@@ -91,7 +91,7 @@ class Score:
 class TestResult:
     """
     Representation of the results of a model test job that was run for a specific
-    model and dataset in an Intel® Geti™ project
+    model and dataset in an Geti™ project
     """
 
     datasets_info: list[DatasetInfo]

--- a/geti_sdk/data_models/user.py
+++ b/geti_sdk/data_models/user.py
@@ -17,7 +17,7 @@ import attr
 @attr.define
 class User:
     """
-    Representation of a User in the Intel Geti platform
+    Representation of a User in the Geti platform
 
     :var name: name of the user
     :var uid: Unique ID of the user

--- a/geti_sdk/demos/__init__.py
+++ b/geti_sdk/demos/__init__.py
@@ -17,7 +17,7 @@ Introduction
 ------------
 
 The `demos` package contains useful functions for setting up demo projects on any
-Intel® Geti™ server.
+Geti™ server.
 
 Module contents
 ---------------

--- a/geti_sdk/demos/demo_projects/anomaly_demos.py
+++ b/geti_sdk/demos/demo_projects/anomaly_demos.py
@@ -49,7 +49,7 @@ def create_anomaly_classification_demo_project(
         the dataset is not found in the target folder, this method will attempt to
         download it from the internet.
     :return: Project object, holding detailed information about the project that was
-        created on the Intel® Geti™ server.
+        created on the Geti™ server.
     """
     project_client = ProjectClient(session=geti.session, workspace_id=geti.workspace_id)
     data_path = get_mvtec_dataset(dataset_path)
@@ -106,7 +106,7 @@ def ensure_trained_anomaly_project(geti: Geti, project_name: str = "Transistor a
     If the project does not exist, this method will create an anomaly detection
     project based on the MVTec AD `transistor` dataset.
 
-    :param geti: Geti instance pointing to the Intel® Geti™ server
+    :param geti: Geti instance pointing to the Geti™ server
     :param project_name: Name of the project to look for or create
     :return: Project object representing the project on the server
     """

--- a/geti_sdk/demos/demo_projects/coco_demos.py
+++ b/geti_sdk/demos/demo_projects/coco_demos.py
@@ -58,7 +58,7 @@ def create_segmentation_demo_project(
         download it from the internet.
     :param project_name: Name of the project to create
     :return: Project object, holding detailed information about the project that was
-        created on the Intel® Geti™ server.
+        created on the Geti™ server.
     """
     coco_path = get_coco_dataset(dataset_path)
     logging.info(" ------- Creating segmentation project --------------- ")
@@ -111,7 +111,7 @@ def create_detection_demo_project(
         download it from the internet.
     :param project_name: Name of the project to create
     :return: Project object, holding detailed information about the project that was
-        created on the Intel® Geti™ server.
+        created on the Geti™ server.
     """
     coco_path = get_coco_dataset(dataset_path)
     logging.info(" ------- Creating detection project --------------- ")
@@ -165,7 +165,7 @@ def create_classification_demo_project(
         download it from the internet.
     :param project_name: Name of the project to create
     :return: Project object, holding detailed information about the project that was
-        created on the Intel® Geti™ server.
+        created on the Geti™ server.
     """
     coco_path = get_coco_dataset(dataset_path)
     logging.info(" ------- Creating classification project --------------- ")
@@ -222,7 +222,7 @@ def create_detection_to_segmentation_demo_project(
         download it from the internet.
     :param project_name: Name of the project to create
     :return: Project object, holding detailed information about the project that was
-        created on the Intel® Geti™ server.
+        created on the Geti™ server.
     """
     coco_path = get_coco_dataset(dataset_path)
     logging.info(" ------- Creating detection -> segmentation project --------------- ")
@@ -284,7 +284,7 @@ def create_detection_to_classification_demo_project(
         download it from the internet.
     :param project_name: Name of the project to create
     :return: Project object, holding detailed information about the project that was
-        created on the Intel® Geti™ server.
+        created on the Geti™ server.
     """
     coco_path = get_coco_dataset(dataset_path)
     logging.info(" ------- Creating detection -> classification project --------------- ")

--- a/geti_sdk/deployment/__init__.py
+++ b/geti_sdk/deployment/__init__.py
@@ -16,9 +16,9 @@
 Introduction
 ------------
 
-The `deployment` package allows creating a deployment of any Intel® Geti™ project.
+The `deployment` package allows creating a deployment of any Geti™ project.
 A project deployment can run inference on an image or video frame locally, i.e.
-without any connection to the Intel® Geti™ server.
+without any connection to the Geti™ server.
 
 Deployments can be created for both single task and task chain projects alike, the API
 is the same in both cases.

--- a/geti_sdk/deployment/deployed_model.py
+++ b/geti_sdk/deployment/deployed_model.py
@@ -67,7 +67,7 @@ OVMS_TIMEOUT = 10  # Max time to wait for OVMS models to become available
 @attr.define
 class DeployedModel(OptimizedModel):
     """
-    Representation of an Intel® Geti™ model that has been deployed for inference. It
+    Representation of an Geti™ model that has been deployed for inference. It
     can be loaded onto a device to generate predictions.
     """
 
@@ -112,7 +112,7 @@ class DeployedModel(OptimizedModel):
         Load the model weights from a data source. The `source` can be one of the
         following:
 
-          1. The Intel® Geti™ platform (if an GetiSession instance is passed). In this
+          1. The Geti™ platform (if an GetiSession instance is passed). In this
             case the weights will be downloaded, and extracted to a temporary directory
           2. A zip file on local disk, in this case the weights will be extracted to a
              temporary directory

--- a/geti_sdk/deployment/deployment.py
+++ b/geti_sdk/deployment/deployment.py
@@ -41,7 +41,7 @@ from .utils import (
 @attr.define(slots=False)
 class Deployment:
     """
-    Representation of a deployed Intel® Geti™ project that can be used to run
+    Representation of a deployed Geti™ project that can be used to run
     inference locally
     """
 

--- a/geti_sdk/deployment/resources/OVMS_README.md
+++ b/geti_sdk/deployment/resources/OVMS_README.md
@@ -1,7 +1,7 @@
 # Deploying Geti models with OpenVINO Model Server (OVMS)
 > Note: This feature is deprecated and is not recommended for use.
 
-This README describes how to set up an OpenVINO Model Server for any Intel® Geti™
+This README describes how to set up an OpenVINO Model Server for any Geti™
 project. Please note that it is meant as an example only, and the configuration used
 may not be optimal for a production environment.
 
@@ -23,7 +23,7 @@ docker pull openvino/model_server:latest
 ```
 
 ## Firing up the OVMS container
-Follow the steps below to run the OVMS container with your Intel® Geti™ trained
+Follow the steps below to run the OVMS container with your Geti™ trained
 model(s):
 
     1. In your terminal, navigate to the directory containing the deployment you want to
@@ -39,7 +39,7 @@ model(s):
         for inference requests on port 9000.
 
 ## Running inference with Geti SDK and OVMS
-The following python snippet can be used to run inference for your Intel® Geti™ project
+The following python snippet can be used to run inference for your Geti™ project
 on the OVMS instance that you just launched:
 ```python
 from geti_sdk.deployment import Deployment

--- a/geti_sdk/geti.py
+++ b/geti_sdk/geti.py
@@ -267,9 +267,7 @@ class Geti:
         """
         project = self.project_client.get_project(project_name=project_name, project_id=project_id, project=project)
         if project is None:
-            raise KeyError(
-                f"Project '{project_name}' was not found in the current workspace on the Geti™ server."
-            )
+            raise KeyError(f"Project '{project_name}' was not found in the current workspace on the Geti™ server.")
         return project
 
     def download_project_data(

--- a/geti_sdk/geti.py
+++ b/geti_sdk/geti.py
@@ -68,11 +68,11 @@ logging.captureWarnings(True)
 
 class Geti:
     """
-    Interact with an Intel® Geti™ server via the REST API.
+    Interact with an Geti™ server via the REST API.
 
     The `Geti` class provides methods for project creation, downloading and
     uploading, as well as project deployment. Initializing the class will establish a
-    HTTP session to the Intel® Geti™ server, and requires authentication.
+    HTTP session to the Geti™ server, and requires authentication.
 
     NOTE: The `Geti` instance can either be initialized in the following ways:
 
@@ -173,7 +173,7 @@ class Geti:
                     "please update the `server_config` accordingly."
                 )
 
-        # Set the Intel Geti SDK version
+        # Set the Geti SDK version
         self.sdk_version = Version(sdk_version_string)
         # Initialize session and get workspace id
         self.session = GetiSession(
@@ -198,36 +198,36 @@ class Geti:
 
     def _check_platform_version(self) -> None:
         """
-        Check the version of the Intel® Geti™ server that this `Geti` instance is
+        Check the version of the Geti™ server that this `Geti` instance is
         connected to. If the version is not supported by the SDK, a warning will be
         issued.
 
-        :raises: ValueError if the Intel® Geti™ server version is not supported by the
-            Intel® Geti™ SDK.
+        :raises: ValueError if the Geti™ server version is not supported by the
+            Geti™ SDK.
         """
         # Get the build version without a timestamp
         platform_version = self.session.version.version
         # Check if the platform version is newer than the SDK version
         if platform_version > self.sdk_version:
             warnings.warn(
-                f"The Intel® Geti™ server version {platform_version} is newer than "
+                f"The Geti™ server version {platform_version} is newer than "
                 f"the Geti SDK version {self.sdk_version}. Some features may not be "
                 "supported and you may encounter errors.\n"
-                "Please update the Intel Geti SDK to the latest version "
+                "Please update the Geti SDK to the latest version "
                 "with `pip install --upgrade geti-sdk`."
             )
         # Check if the platform version is older than the last supported version
         if self.session.version < GETI_116_VERSION:
             raise ValueError(
-                "The Intel® Geti™ server version is not supported by this Intel Geti SDK package. Please "
-                "update the Intel® Geti™ server to version 2.0 or later, or use a previous version of the SDK."
+                "The Geti™ server version is not supported by this Geti SDK package. Please "
+                "update the Geti™ server to version 2.0 or later, or use a previous version of the SDK."
             )
 
     @property
     def projects(self) -> list[Project]:
         """
         Return a list of projects that are currently available in the workspace on
-        the Intel® Geti™ server.
+        the Geti™ server.
 
         :return: List of projects in the workspace addressed by the current `Geti`
             instance
@@ -251,9 +251,9 @@ class Geti:
         project: Project | None = None,
     ) -> Project:
         """
-        Return the Intel® Geti™ project by name or ID, if any.
+        Return the Geti™ project by name or ID, if any.
         If a project object is passed, the method will return the updated object.
-        If no project by that name is found on the Intel® Geti™ server,
+        If no project by that name is found on the Geti™ server,
         this method will raise a KeyError.
 
         :param project_name: Name of the project to retrieve.
@@ -268,7 +268,7 @@ class Geti:
         project = self.project_client.get_project(project_name=project_name, project_id=project_id, project=project)
         if project is None:
             raise KeyError(
-                f"Project '{project_name}' was not found in the current workspace on the Intel® Geti™ server."
+                f"Project '{project_name}' was not found in the current workspace on the Geti™ server."
             )
         return project
 
@@ -370,7 +370,7 @@ class Geti:
         max_threads: int = 5,
     ) -> Project:
         """
-        Upload a previously downloaded Intel® Geti™ project to the server. This method
+        Upload a previously downloaded Geti™ project to the server. This method
         expects the `target_folder` to contain the following:
 
             images
@@ -413,7 +413,7 @@ class Geti:
 
     def download_all_projects(self, target_folder: str, include_predictions: bool = True) -> list[Project]:
         """
-        Download all projects in the workspace from the Intel® Geti™ server.
+        Download all projects in the workspace from the Geti™ server.
 
         :param target_folder: Directory on local disk to download the project data to.
             If not specified, this method will create a directory named 'projects' in
@@ -423,7 +423,7 @@ class Geti:
             If this is set to True but the project has no trained models, downloading
             predictions will be skipped.
         :return: List of Project objects, each entry corresponding to one of the
-            projects found on the Intel® Geti™ server
+            projects found on the Geti™ server
         """
         return self.import_export_module.download_all_projects(
             target_folder=target_folder, include_predictions=include_predictions
@@ -432,7 +432,7 @@ class Geti:
     def upload_all_projects(self, target_folder: str) -> list[Project]:
         """
         Upload all projects found in the directory `target_folder` on local disk to
-        the Intel® Geti™ server.
+        the Geti™ server.
 
         This method expects the directory `target_folder` to contain subfolders. Each
         subfolder should correspond to the (previously downloaded) data for one
@@ -442,7 +442,7 @@ class Geti:
 
         :param target_folder: Directory on local disk to retrieve the project data from
         :return: List of Project objects, each entry corresponding to one of the
-            projects uploaded to the Intel® Geti™ server.
+            projects uploaded to the Geti™ server.
         """
         return self.import_export_module.upload_all_projects(target_folder=target_folder)
 
@@ -457,7 +457,7 @@ class Geti:
         Export a project with name `project_name` to the file specified by `filepath`.
         The project will be saved in a .zip file format, containing all project data,
         with the option to include all, none or only the latest_active model, indicated by `include_models`.
-        and metadata required for project import to another instance of the Intel® Geti™ platform.
+        and metadata required for project import to another instance of the Geti™ platform.
 
         :param filepath: Path to the file to save the project to
         :param project_id: Id of the project to export
@@ -486,7 +486,7 @@ class Geti:
 
     def import_project(self, filepath: os.PathLike, project_name: str | None = None) -> Project:
         """
-        Import a project from the zip file specified by `filepath` to the Intel® Geti™ server.
+        Import a project from the zip file specified by `filepath` to the Geti™ server.
         The project will be created on the server with the name `project_name`, if
         specified, esle with the archive base name.
         > Note: The project zip archive should be exported from the Geti™ server of the same version.
@@ -532,7 +532,7 @@ class Geti:
 
     def import_dataset(self, filepath: os.PathLike, project_name: str, project_type: str) -> Project:
         """
-        Import a dataset from the zip archive specified by `filepath` to the Intel® Geti™ server.
+        Import a dataset from the zip archive specified by `filepath` to the Geti™ server.
         A new project will be created from the dataset on the server with the name `project_name`.
         Please set the `project_type` to determine the type of the project with one of possible values are:
 
@@ -577,7 +577,7 @@ class Geti:
         max_threads: int = 5,
     ) -> Project:
         """
-        Create a single task project named `project_name` on the Intel® Geti™ server,
+        Create a single task project named `project_name` on the Geti™ server,
         and upload data from a dataset on local disk.
 
         The type of task that will be in the project can be controlled by setting the
@@ -706,7 +706,7 @@ class Geti:
         max_threads: int = 5,
     ) -> Project:
         """
-        Create a single task project named `project_name` on the Intel® Geti™ cluster,
+        Create a single task project named `project_name` on the Geti™ cluster,
         and upload data from a dataset on local disk.
 
         The type of task that will be in the project can be controlled by setting the
@@ -822,14 +822,14 @@ class Geti:
     ) -> bool:
         """
         Upload a folder with media (images, videos or both) from local disk at path
-        `target_folder` to the project provided with the `project` argument on the Intel® Geti™
+        `target_folder` to the project provided with the `project` argument on the Geti™
         server.
         After the media upload is complete, predictions will be downloaded for all
         media in the folder. This method will create a 'predictions' directory in
         the `target_folder`, containing the prediction output in json format.
 
         If `delete_after_prediction` is set to True, all uploaded media will be
-        removed from the project on the Intel® Geti™ server after the predictions have
+        removed from the project on the Geti™ server after the predictions have
         been downloaded.
 
         :param project: Project object to upload the media to
@@ -909,7 +909,7 @@ class Geti:
         dataset_name: str | None = None,
     ) -> tuple[Image, Prediction]:
         """
-        Upload a single image to a project on the Intel® Geti™
+        Upload a single image to a project on the Geti™
         server, and return a prediction for it.
 
         :param project: Project object to upload the image to
@@ -978,7 +978,7 @@ class Geti:
         delete_after_prediction: bool = False,
     ) -> tuple[Video, MediaList[VideoFrame], list[Prediction]]:
         """
-        Upload a single video to a project on the Intel® Geti™
+        Upload a single video to a project on the Geti™
         server, and return a list of predictions for the frames in the video.
 
         The parameter 'frame_stride' is used to control the stride for frame
@@ -1103,7 +1103,7 @@ class Geti:
 
     def logout(self) -> None:
         """
-        Log out of the Intel® Geti™ platform and end the HTTP session.
+        Log out of the Geti™ platform and end the HTTP session.
         """
         self.session.logout()
 

--- a/geti_sdk/http_session/exception.py
+++ b/geti_sdk/http_session/exception.py
@@ -17,7 +17,7 @@ from typing import BinaryIO
 
 class GetiRequestException(Exception):
     """
-    Exception representing an unsuccessful http request to the Intel® Geti™ server.
+    Exception representing an unsuccessful http request to the Geti™ server.
     """
 
     def __init__(
@@ -29,7 +29,7 @@ class GetiRequestException(Exception):
         response_data: dict | str | list | None = None,
     ):
         """
-        Raise this exception upon unsuccessful requests to the Intel® Geti™ server.
+        Raise this exception upon unsuccessful requests to the Geti™ server.
 
         :param method: Method that was used for the request, e.g. 'POST' or 'GET', etc.
         :param url: URL to which the request was made
@@ -61,7 +61,7 @@ class GetiRequestException(Exception):
     def __str__(self) -> str:
         """
         Return string representation of the unsuccessful http request to the
-        Intel® Geti™ server.
+        Geti™ server.
         """
         error_str = f"{self.method} request to '{self.url}' failed with status code {self.status_code}."
         if self.response_error_code and self.response_message:

--- a/geti_sdk/http_session/geti_session.py
+++ b/geti_sdk/http_session/geti_session.py
@@ -50,7 +50,7 @@ class GetiSession(requests.Session):
     handles authentication and authorization.
 
     :param server_config: Server configuration holding the hostname (or ip address) of
-        the Intel® Geti™ server, as well as the details required for authentication
+        the Geti™ server, as well as the details required for authentication
         (either username and password or personal access token)
     """
 
@@ -77,7 +77,7 @@ class GetiSession(requests.Session):
         if not server_config.has_valid_certificate:
             warnings.warn(
                 "You have disabled TLS certificate validation, HTTPS requests made to "
-                "the Intel® Geti™ server may be compromised. For optimal security, "
+                "the Geti™ server may be compromised. For optimal security, "
                 "please enable certificate validation.",
                 InsecureRequestWarning,
             )
@@ -93,7 +93,7 @@ class GetiSession(requests.Session):
             if self.platform_serving_mode == SAAS_MODE:
                 raise ValueError(
                     "Authentication via username and password is not supported for "
-                    "Intel® Geti™ SaaS instances. Please use a personal access token."
+                    "Geti™ SaaS instances. Please use a personal access token."
                 )
             logging.warning(
                 "Authentication via username and password is deprecated and will be "
@@ -135,9 +135,9 @@ class GetiSession(requests.Session):
     @property
     def version(self) -> GetiVersion:
         """
-        Return the version of the Intel® Geti™ platform that is running on the server.
+        Return the version of the Geti™ platform that is running on the server.
 
-        :return: Version object holding the Intel® Geti™ version number
+        :return: Version object holding the Geti™ version number
         """
         if "build-version" in self._product_info:
             version_string = self._product_info.get("build-version")
@@ -187,18 +187,18 @@ class GetiSession(requests.Session):
             login_path = self._get_initial_login_url()
         except requests.exceptions.SSLError as error:
             raise requests.exceptions.SSLError(
-                f"Connection to Intel® Geti™ server at '{self.config.host}' failed, "
+                f"Connection to Geti™ server at '{self.config.host}' failed, "
                 f"the server address can be resolved but the SSL certificate could not "
                 f"be verified. \n Full error description: {error.args[-1]}"
             )
         except requests.exceptions.ConnectionError as error:
             if "dummy" in self.config.password or "dummy" in self.config.username:
                 raise ValueError(
-                    "Connection to the Intel® Geti™ server failed, please make sure to "
-                    "update the user login information for the Intel® Geti™ instance."
+                    "Connection to the Geti™ server failed, please make sure to "
+                    "update the user login information for the Geti™ instance."
                 ) from error
             raise ValueError(
-                f"Connection to the Intel® Geti™ server at host '{self.config.host}' "
+                f"Connection to the Geti™ server at host '{self.config.host}' "
                 f"failed, please provide a valid cluster hostname or ip address as"
                 f" well as valid login details."
             ) from error
@@ -273,7 +273,7 @@ class GetiSession(requests.Session):
             else:
                 raise ValueError(
                     f"Making a POST request with content of type {contenttype} is "
-                    f"currently not supported through the Intel Geti SDK."
+                    f"currently not supported through the Geti SDK."
                 )
         else:
             kw_data_arg = {}
@@ -303,7 +303,7 @@ class GetiSession(requests.Session):
                 break
             except requests.exceptions.SSLError as error:
                 raise requests.exceptions.SSLError(
-                    f"Connection to Intel® Geti™ server at '{self.config.host}' failed, "
+                    f"Connection to Geti™ server at '{self.config.host}' failed, "
                     f"the server address can be resolved but the SSL certificate could not "
                     f"be verified. \n Full error description: {error.args[-1]}"
                 )
@@ -385,7 +385,7 @@ class GetiSession(requests.Session):
 
     def _get_product_info_and_set_api_version(self) -> dict[str, str]:
         """
-        Return the product info as retrieved from the Intel® Geti™ server.
+        Return the product info as retrieved from the Geti™ server.
 
         This method will also attempt to set the API version correctly, based on the
         retrieved product info.
@@ -396,7 +396,7 @@ class GetiSession(requests.Session):
 
     def __exit__(self, exc_type, exc_value, traceback):
         """
-        Log out of the Intel® Geti™ server. This method is called when exiting the
+        Log out of the Geti™ server. This method is called when exiting the
         runtime context related to the session, in case the session is used as a context
         manager.
         """
@@ -409,7 +409,7 @@ class GetiSession(requests.Session):
 
     def __del__(self):
         """
-        Log out of the Intel® Geti™ server. This method is called when the session is
+        Log out of the Geti™ server. This method is called when the session is
         deleted from memory.
         """
         if self.logged_in:
@@ -515,7 +515,7 @@ class GetiSession(requests.Session):
     @property
     def base_url(self) -> str:
         """
-        Return the base URL to the Intel Geti server. If the server is running
+        Return the base URL to the Geti server. If the server is running
         Geti v1.9 or later, the organization ID will be included in the URL
         """
         return f"{self.config.base_url}organizations/{self.organization_id}/"
@@ -559,7 +559,7 @@ class GetiSession(requests.Session):
 
         if org_id is None:
             raise ValueError(
-                f"Unable to retrieve organization ID from the Intel Geti server. Server responded with: `{result}`"
+                f"Unable to retrieve organization ID from the Geti server. Server responded with: `{result}`"
             )
         return org_id
 
@@ -605,11 +605,11 @@ class GetiSession(requests.Session):
             )
         elif response.status_code == 404:
             raise ValueError(
-                "Unable to authenticate with the Intel Geti server. The authentication "
+                "Unable to authenticate with the Geti server. The authentication "
                 "mechanism you are trying to use is no longer supported. This error "
-                "indicates that the Intel® Geti™ server version is not supported by "
-                "this version of the Intel Geti SDK package. Please update the "
-                "Intel® Geti™ server to version 2.0 or later, or use a previous "
+                "indicates that the Geti™ server version is not supported by "
+                "this version of the Geti SDK package. Please update the "
+                "Geti™ server to version 2.0 or later, or use a previous "
                 "version of the SDK."
             )
         else:

--- a/geti_sdk/http_session/server_config.py
+++ b/geti_sdk/http_session/server_config.py
@@ -32,10 +32,10 @@ def trim_trailing_slash(input_string: str) -> str:
 @attrs.define(slots=False)
 class ServerConfig:
     """
-    Base configuration holding the connection details of the Intel® Geti™ server.
+    Base configuration holding the connection details of the Geti™ server.
     Contains the hostname, ssl certificate configuration and proxy configuration.
 
-    :var host: full hostname or ip address of the Intel® Geti™ server.
+    :var host: full hostname or ip address of the Geti™ server.
         Note: this should include the protocol (i.e. https://your_geti_hostname.com)
     :var has_valid_certificate: Set to True if the server has a valid SSL certificate
         that should be validated and used to establish an encrypted HTTPS connection
@@ -104,7 +104,7 @@ class ServerConfig:
 @attrs.define(slots=False)
 class ServerCredentialConfig(ServerConfig):
     """
-    Configuration for an Intel® Geti™ server that requires authentication via username
+    Configuration for an Geti™ server that requires authentication via username
     and password.
 
     NOTE: This is a legacy authentication method. Recent server versions should
@@ -121,7 +121,7 @@ class ServerCredentialConfig(ServerConfig):
 @attrs.define(slots=False)
 class ServerTokenConfig(ServerConfig):
     """
-    Configuration for an Intel® Geti™ server that uses a personal access token
+    Configuration for an Geti™ server that uses a personal access token
     (API key) for authentication.
 
     :var token: Personal access token that can be used to connect to the server.
@@ -133,7 +133,7 @@ class ServerTokenConfig(ServerConfig):
 @attrs.define(slots=False)
 class SaaSTokenConfig(ServerTokenConfig):
     """
-    Configuration for the Intel® Geti™ SaaS environment that uses a personal access token
+    Configuration for the Geti™ SaaS environment that uses a personal access token
     (API key) for authentication.
 
     :var token: Personal access token that can be used to connect to the server.

--- a/geti_sdk/import_export/__init__.py
+++ b/geti_sdk/import_export/__init__.py
@@ -17,7 +17,7 @@ Introduction
 ------------
 
 The `import-export` package contains the `GetiIE` class with number of methods for importing and
-exporting projets and datasets to and from the Intel® Geti™ platform.
+exporting projets and datasets to and from the Geti™ platform.
 
 Module contents
 ---------------

--- a/geti_sdk/import_export/import_export_module.py
+++ b/geti_sdk/import_export/import_export_module.py
@@ -30,7 +30,7 @@ from geti_sdk.utils.project_helpers import get_project_folder_name
 
 class GetiIE:
     """
-    Class to handle importing and exporting projects and datasets to and from the Intel® Geti™ platform.
+    Class to handle importing and exporting projects and datasets to and from the Geti™ platform.
     """
 
     def __init__(self, workspace_id: str, session: GetiSession, project_client: ProjectClient) -> None:
@@ -248,7 +248,7 @@ class GetiIE:
         os.makedirs(target_folder, exist_ok=True, mode=0o770)
         logging.info(
             f"Found {len(projects)} projects in the designated workspace on the "
-            f"Intel® Geti™ server. Commencing project download..."
+            f"Geti™ server. Commencing project download..."
         )
 
         # Download all found projects

--- a/geti_sdk/platform_versions.py
+++ b/geti_sdk/platform_versions.py
@@ -18,7 +18,7 @@ from semver import Version as SemVersion
 
 class GetiVersion:
     """
-    Version identifier of the Intel Geti platform
+    Version identifier of the Geti platform
     """
 
     _GETI10_TIMETAG = "20220910154208"
@@ -78,7 +78,7 @@ class GetiVersion:
         :param other: GetiVersion object to compare with
         :raises: TypeError if `other` is not a GetiVersion instance
         :return: True if this instance corresponds to a later or equivalent version of
-            the Intel Geti platform than `other`
+            the Geti platform than `other`
         """
         return (self > other) or (self == other)
 
@@ -90,7 +90,7 @@ class GetiVersion:
         :param other: GetiVersion object to compare with
         :raises: TypeError if `other` is not a GetiVersion instance
         :return: True if this instance corresponds to an earlier or equivalent version
-            of the Intel Geti platform than `other`
+            of the Geti platform than `other`
         """
         return (self < other) or (self == other)
 
@@ -108,7 +108,7 @@ class GetiVersion:
 
     def __str__(self) -> str:
         """
-        Return the Intel Geti version as a string
+        Return the Geti version as a string
 
         :return: String containing the version
         """
@@ -116,7 +116,7 @@ class GetiVersion:
 
     def __repr__(self) -> str:
         """
-        Return the string representation of the Intel Geti version
+        Return the string representation of the Geti version
 
         :return: String representing the version
         """

--- a/geti_sdk/post_inference_hooks/actions/geti_data_collection.py
+++ b/geti_sdk/post_inference_hooks/actions/geti_data_collection.py
@@ -37,9 +37,9 @@ from geti_sdk.rest_clients.project_client.project_client import ProjectClient
 class GetiDataCollection(PostInferenceAction):
     """
     Post inference action that will send an image to a specified `project` and `dataset`
-    on the Intel® Geti™ server addressed by `session`.
+    on the Geti™ server addressed by `session`.
 
-    :param session: Geti session representing the connecting to the Intel® Geti™ server
+    :param session: Geti session representing the connecting to the Geti™ server
     :param workspace_id: unique ID of the workspace in which the project to collect
         the data resides.
     :param project: Project or name of the project to whicht the image data should be
@@ -67,8 +67,8 @@ class GetiDataCollection(PostInferenceAction):
             project = project_client.get_project_by_name(project_name=project_name)
             if project is None:
                 raise ValueError(
-                    f"Project `{project_name}` does not exist on the Intel® Geti™ "
-                    f"server, unable to initialize the Intel® Geti™ data collection "
+                    f"Project `{project_name}` does not exist on the Geti™ "
+                    f"server, unable to initialize the Geti™ data collection "
                     f"action"
                 )
         dataset_client = DatasetClient(session=session, workspace_id=workspace_id, project=project)
@@ -103,7 +103,7 @@ class GetiDataCollection(PostInferenceAction):
         timestamp: datetime | None = None,
     ):
         """
-        Execute the action, upload the given `image` to the Intel® Geti™ server.
+        Execute the action, upload the given `image` to the Geti™ server.
 
         The parameters `prediction`, `score`, `name` and `timestamp` are not used in
         this specific action.
@@ -154,7 +154,7 @@ class GetiDataCollection(PostInferenceAction):
         """
         warnings.warn(
             "GetiDataCollection post inference action contains sensitive information "
-            "used for authentication on the Intel® Geti™ platform. Be careful when "
+            "used for authentication on the Geti™ platform. Be careful when "
             "saving this information to disk or sharing with others!"
         )
         return super().to_dict()

--- a/geti_sdk/prediction_visualization/__init__.py
+++ b/geti_sdk/prediction_visualization/__init__.py
@@ -33,7 +33,7 @@ then use it to draw the annotations on the input image.
       show_count=False,
    )
 
-   # Obtain a prediction from the Intel Geti platfor server or a local deployment.
+   # Obtain a prediction from the Geti platfor server or a local deployment.
    ...
 
    # Visualize the prediction on the input image.

--- a/geti_sdk/rest_clients/__init__.py
+++ b/geti_sdk/rest_clients/__init__.py
@@ -20,7 +20,7 @@ The `rest_clients` package contains clients for interacting with the various ent
 such as :py:class:`~geti_sdk.data_models.project.Project`,
 :py:class:`~geti_sdk.data_models.media.Image` and
 :py:class:`~geti_sdk.data_models.model.Model`)
-on the Intel® Geti™ server.
+on the Geti™ server.
 
 The rest clients are initialized with a
 :py:class:`~geti_sdk.http_session.geti_session.GetiSession` and a workspace id. The

--- a/geti_sdk/rest_clients/active_learning_client.py
+++ b/geti_sdk/rest_clients/active_learning_client.py
@@ -19,7 +19,7 @@ from geti_sdk.rest_converters import MediaRESTConverter
 
 class ActiveLearningClient:
     """
-    Class to manage the active learning for a certain Intel® Geti™ project.
+    Class to manage the active learning for a certain Geti™ project.
     """
 
     def __init__(self, workspace_id: str, project: Project, session: GetiSession):

--- a/geti_sdk/rest_clients/annotation_clients/annotation_client.py
+++ b/geti_sdk/rest_clients/annotation_clients/annotation_client.py
@@ -306,7 +306,7 @@ class AnnotationClient(BaseAnnotationClient, Generic[AnnotationReaderType]):
 
     def upload_annotation(self, media_item: Image | VideoFrame, annotation_scene: AnnotationScene) -> AnnotationScene:
         """
-        Upload an annotation for an image or video frame to the Intel® Geti™ server.
+        Upload an annotation for an image or video frame to the Geti™ server.
 
         :param media_item: Image or VideoFrame to apply and upload the annotation to
         :param annotation_scene: AnnotationScene to upload
@@ -324,7 +324,7 @@ class AnnotationClient(BaseAnnotationClient, Generic[AnnotationReaderType]):
     def get_annotation(self, media_item: Image | VideoFrame) -> AnnotationScene | None:
         """
         Retrieve the latest annotations for an image or video frame from the
-        Intel® Geti™ platform.
+        Geti™ platform.
         If no annotation is available, this method returns None.
 
         :param media_item: Image or VideoFrame to retrieve the annotations for

--- a/geti_sdk/rest_clients/annotation_clients/base_annotation_client.py
+++ b/geti_sdk/rest_clients/annotation_clients/base_annotation_client.py
@@ -135,7 +135,7 @@ class BaseAnnotationClient:
             if label.is_empty:
                 # We perform a casefold on the label name to ensure that we can match
                 # the empy labels from projects created in older versions of the
-                # Intel Geti platform.
+                # Geti platform.
                 label_name = label.name.casefold()
             else:
                 label_name = label.name
@@ -324,7 +324,7 @@ class BaseAnnotationClient:
         self, response_dict: dict[str, Any], media_information: MediaInformation
     ) -> AnnotationScene:
         """
-        Convert a dictionary with annotation data obtained from the Intel® Geti™
+        Convert a dictionary with annotation data obtained from the Geti™
         /annotations rest endpoint into an annotation scene.
 
         :param response_dict: Dictionary containing the annotation data

--- a/geti_sdk/rest_clients/credit_system_client.py
+++ b/geti_sdk/rest_clients/credit_system_client.py
@@ -31,7 +31,7 @@ def allow_supported(func):
     def wrapper(instance, *args, **kwargs):
         if instance._is_supported:
             return func(instance, *args, **kwargs)
-        logging.warning("Credit System is not supported by the Intel Geti Platform.")
+        logging.warning("Credit System is not supported by the Geti Platform.")
         return None
 
     return wrapper
@@ -39,7 +39,7 @@ def allow_supported(func):
 
 class CreditSystemClient:
     """
-    Class to work with credits in Intel Geti.
+    Class to work with credits in Geti.
     """
 
     def __init__(self, session: GetiSession, workspace_id: str | None = None):
@@ -48,12 +48,12 @@ class CreditSystemClient:
             self.workspace_id = workspace_id
         else:
             self.workspace_id = get_workspace_id(self.session)
-        # Make sure the Intel Geti Platform supports Credit System.
+        # Make sure the Geti Platform supports Credit System.
         self._is_supported = self.is_supported()
 
     def is_supported(self) -> bool:
         """
-        Check if the Intel Geti Platform supports Credit system.
+        Check if the Geti Platform supports Credit system.
 
         :return: True if the Credit System is supported, False otherwise.
         """

--- a/geti_sdk/rest_clients/dataset_client.py
+++ b/geti_sdk/rest_clients/dataset_client.py
@@ -33,7 +33,7 @@ from geti_sdk.utils import deserialize_dictionary
 
 class DatasetClient:
     """
-    Class to manage datasets for a certain Intel® Geti™ project.
+    Class to manage datasets for a certain Geti™ project.
     """
 
     def __init__(self, workspace_id: str, project: Project, session: GetiSession):
@@ -85,7 +85,7 @@ class DatasetClient:
 
     def get_all_datasets(self) -> list[Dataset]:
         """
-        Query the Intel® Geti™ server to retrieve an up to date list of datasets in
+        Query the Geti™ server to retrieve an up to date list of datasets in
         the project.
 
         :return: List of current datasets in the project

--- a/geti_sdk/rest_clients/deployment_client.py
+++ b/geti_sdk/rest_clients/deployment_client.py
@@ -37,7 +37,7 @@ from geti_sdk.utils import get_supported_algorithms
 
 class DeploymentClient:
     """
-    Class to manage model deployment for a certain Intel® Geti™ project.
+    Class to manage model deployment for a certain Geti™ project.
     """
 
     def __init__(self, workspace_id: str, project: Project, session: GetiSession):
@@ -62,7 +62,7 @@ class DeploymentClient:
         """
         Return the base URL for the deployment group of endpoints
 
-        :return: URL for the deployment endpoints for the Intel® Geti™ project
+        :return: URL for the deployment endpoints for the Geti™ project
         """
         return self.base_url + "/deployment_package"
 

--- a/geti_sdk/rest_clients/media_client/media_client.py
+++ b/geti_sdk/rest_clients/media_client/media_client.py
@@ -167,7 +167,7 @@ class BaseMediaClient(Generic[MediaTypeVar]):
         :param buffer: BinaryIO object representing a media file
         :param dataset: Dataset to upload the media to. If no dataset is passed, the
             media will be uploaded into the default (training) dataset
-        :return: Dictionary containing the response of the Intel® Geti™ server, which
+        :return: Dictionary containing the response of the Geti™ server, which
             holds the details of the uploaded entity
         """
         if dataset is None:
@@ -186,7 +186,7 @@ class BaseMediaClient(Generic[MediaTypeVar]):
         :param filepath: full path to the media file on disk
         :param dataset: Dataset to upload the media to. If no dataset is passed, the
             media will be uploaded into the default (training) dataset
-        :return: Dictionary containing the response of the Intel® Geti™ server, which
+        :return: Dictionary containing the response of the Geti™ server, which
             holds the details of the uploaded entity
         """
         with open(filepath, "rb") as f:
@@ -284,7 +284,7 @@ class BaseMediaClient(Generic[MediaTypeVar]):
     ) -> MediaList[MediaTypeVar]:
         """
         Upload all media in a folder to the project. Returns the mapping of filenames
-        to the unique IDs assigned by Intel Geti.
+        to the unique IDs assigned by Geti.
 
         :param path_to_folder: Folder with media items to upload
         :param n_media: Number of media to upload from folder

--- a/geti_sdk/rest_clients/media_client/video_client.py
+++ b/geti_sdk/rest_clients/media_client/video_client.py
@@ -121,7 +121,7 @@ class VideoClient(BaseMediaClient[Video]):
     ) -> MediaList[Video]:
         """
         Upload all videos in a folder to the project. Returns the mapping of video
-        filename to the unique ID assigned by Intel Geti.
+        filename to the unique ID assigned by Geti.
 
         :param path_to_folder: Folder with videos to upload
         :param n_videos: Number of videos to upload from folder

--- a/geti_sdk/rest_clients/model_client.py
+++ b/geti_sdk/rest_clients/model_client.py
@@ -192,7 +192,7 @@ class ModelClient:
         task: Task | None = None,
     ) -> Model | None:
         """
-        Retrieve a Model from the Intel® Geti™ server, corresponding to a specific
+        Retrieve a Model from the Geti™ server, corresponding to a specific
         algorithm and model version. If no version is passed, this method will
         retrieve the latest model for the algorithm.
 
@@ -327,7 +327,7 @@ class ModelClient:
 
         :param task: Task object containing details of the task to get the model for
         :return: Model object representing the currently active model in the
-            Intel® Geti™ project, if any
+            Geti™ project, if any
         """
         model_groups = self.get_all_model_groups()
         model_id: str | None = None
@@ -429,7 +429,7 @@ class ModelClient:
         the index of that task will be None
 
         :return: Model object representing the currently active model for the task in
-            the Intel® Geti™ project, if any
+            the Geti™ project, if any
         """
         return [self.get_active_model_for_task(task=task) for task in self.project.get_trainable_tasks()]
 
@@ -443,7 +443,7 @@ class ModelClient:
         :param path_to_folder: Path to the target folder in which to save the active
             models, and all optimized models derived from them.
         :return: List of Model objects representing the currently active models
-            (if any) for all tasks in the Intel® Geti™ project. The index of the
+            (if any) for all tasks in the Geti™ project. The index of the
             Model in the list corresponds to the index of the task in the list of
             trainable tasks for the project.
         """
@@ -454,7 +454,7 @@ class ModelClient:
 
     def get_model_for_job(self, job: Job, check_status: bool = True) -> Model:
         """
-        Return the model that was created by the `job` from the Intel® Geti™ server.
+        Return the model that was created by the `job` from the Geti™ server.
 
         :param job: Job to retrieve the model for
         :param check_status: True to first update the status of the job, to make sure
@@ -544,7 +544,7 @@ class ModelClient:
         :param optimization_type: DEPRECATED. Type of optimization to run. Currently
             supported values: ["pot"]. Case insensitive. Defaults to "pot"
         :return: Job object referring to the optimization job running on the
-            Intel® Geti™ server.
+            Geti™ server.
         """
         if isinstance(model, OptimizedModel):
             raise ValueError(
@@ -569,10 +569,10 @@ class ModelClient:
 
     def purge_model(self, model: Model | ModelSummary) -> None:
         """
-        Purge the model from the Intel® Geti™ server.
+        Purge the model from the Geti™ server.
 
         This will permanently delete all the files related to the model including base model weights,
-        optimized model weights and exportable code for the Intel® Geti™ server.
+        optimized model weights and exportable code for the Geti™ server.
 
         :param model: Model to archive. Only base models are accepted, not optimized models.
             Note: the model must not be the latest in the model group or be the active model.

--- a/geti_sdk/rest_clients/prediction_client.py
+++ b/geti_sdk/rest_clients/prediction_client.py
@@ -44,7 +44,7 @@ from geti_sdk.rest_converters.prediction_rest_converter import PredictionRESTCon
 
 class PredictionClient:
     """
-    Class to download predictions from an existing Intel® Geti™ project.
+    Class to download predictions from an existing Geti™ project.
     """
 
     def __init__(self, session: GetiSession, project: Project, workspace_id: str):
@@ -116,7 +116,7 @@ class PredictionClient:
     def mode(self, new_mode: str | PredictionMode):
         """
         Set the mode for the Prediction client to retrieve predictions from the
-        Intel® Geti™ server.
+        Geti™ server.
 
         :param new_mode: PredictionMode (or string representing a prediction mode) to
             set
@@ -285,7 +285,7 @@ class PredictionClient:
 
     def get_image_prediction(self, image: Image) -> Prediction:
         """
-        Get a prediction for an image from the Intel® Geti™ server, if available.
+        Get a prediction for an image from the Geti™ server, if available.
 
         NOTE: This method is only available for images that are already existing on
         the server! For getting predictions on a 'new' image, please see the
@@ -302,7 +302,7 @@ class PredictionClient:
 
     def get_video_frame_prediction(self, video_frame: VideoFrame) -> Prediction:
         """
-        Get a prediction for a video frame from the Intel® Geti™ server, if available.
+        Get a prediction for a video frame from the Geti™ server, if available.
 
         :param video_frame: VideoFrame to get the prediction for. The frame has to be
             present in the project on the cluster already.
@@ -315,7 +315,7 @@ class PredictionClient:
 
     def get_video_predictions(self, video: Video) -> list[Prediction]:
         """
-        Get a list of predictions for a video from the Intel® Geti™ server, if available.
+        Get a list of predictions for a video from the Geti™ server, if available.
 
         :param video: Video to get the predictions for. The video has to be present in
             the project on the cluster already.
@@ -582,7 +582,7 @@ class PredictionClient:
 
     def predict_image(self, image: Image | np.ndarray | os.PathLike | str) -> Prediction:
         """
-        Push an image to the Intel® Geti™ project and receive a prediction for it.
+        Push an image to the Geti™ project and receive a prediction for it.
 
         Note that this method will not save the image to the project.
 

--- a/geti_sdk/rest_clients/project_client/project_client.py
+++ b/geti_sdk/rest_clients/project_client/project_client.py
@@ -62,7 +62,7 @@ TASK_TYPE_MAPPING = {
 
 class ProjectClient:
     """
-    Class to manipulate projects on the Intel® Geti™ server, within a certain workspace.
+    Class to manipulate projects on the Geti™ server, within a certain workspace.
     """
 
     def __init__(self, session: GetiSession, workspace_id: str):
@@ -72,16 +72,16 @@ class ProjectClient:
 
     def get_all_projects(self, request_page_size: int = 50, get_project_details: bool = True) -> list[Project]:
         """
-        Return a list of projects found on the Intel® Geti™ server
+        Return a list of projects found on the Geti™ server
 
         :param request_page_size: Max number of projects to fetch in a single HTTP
             request. Higher values may reduce the response time of this method when
             there are many projects, but increase the chance of timeout.
         :param get_project_details: True to get all details of the projects on the
-            Intel® Geti™, False to fetch only a summary of each project. Set this to
+            Geti™, False to fetch only a summary of each project. Set this to
             False if minimizing latency is a concern. Defaults to True
         :return: List of Project objects, containing the project information for each
-            project on the Intel® Geti™ server
+            project on the Geti™ server
         """
         # The 'projects' endpoint uses pagination: multiple HTTP may be necessary to
         # fetch the full list of projects
@@ -112,7 +112,7 @@ class ProjectClient:
         project_name: str,
     ) -> Project | None:
         """
-        Get a project from the Intel® Geti™ server by project_name.
+        Get a project from the Geti™ server by project_name.
 
         If multiple projects with the same name exist on the server, this method will
         raise a ValueError. In that case, please use the `ProjectClient.get_project()`
@@ -210,9 +210,9 @@ class ProjectClient:
     def download_project_info(self, project: Project, path_to_folder: str) -> None:
         """
         Get the project data that can be used for project creation on
-        the Intel® Geti™ server. From the returned data, the
+        the Geti™ server. From the returned data, the
         method `ProjectClient.get_or_create_project` can create a project on the
-        Intel® Geti™ server. The data is retrieved from the cluster and saved in the
+        Geti™ server. The data is retrieved from the cluster and saved in the
         target folder `path_to_folder`.
 
         :param project: Project to download the data for
@@ -346,8 +346,8 @@ class ProjectClient:
     def _is_project_dir(path_to_folder: str) -> bool:
         """
         Check if the folder specified in `path_to_folder` is a directory
-        containing valid Intel® Geti™ project data that can be used to upload to an
-        Intel® Geti™ server.
+        containing valid Geti™ project data that can be used to upload to an
+        Geti™ server.
 
         :param path_to_folder: Directory to check
         :return: True if the directory holds project data, False otherwise
@@ -411,8 +411,8 @@ class ProjectClient:
         task_names_in_template: list[str] = [previous_task_name]
         is_first_task = True
         for task_type, task_labels in zip(get_task_types_by_project_type(project_type), labels):
-            # Anomaly task reduction introduced in Intel Geti 2.5
-            # The last on-premises version of Intel Geti to support legacy anomaly projects is 2.0
+            # Anomaly task reduction introduced in Geti 2.5
+            # The last on-premises version of Geti to support legacy anomaly projects is 2.0
             if self.session.version >= GETI_25_VERSION and task_type.is_anomaly and task_type != TaskType.ANOMALY:
                 logging.info(f"The {task_type} task is mapped to {TaskType.ANOMALY}.")
                 task_type = TaskType.ANOMALY
@@ -660,7 +660,7 @@ class ProjectClient:
 
     def _await_project_ready(self, project: Project, timeout: int = 5, interval: int = 1) -> None:
         """
-        Await the completion of the project creation process on the Intel® Geti™ server
+        Await the completion of the project creation process on the Geti™ server
 
         :param project: Project object representing the project
         :param timeout: Time (in seconds) after which the method will time out and
@@ -682,7 +682,7 @@ class ProjectClient:
 
     def get_project_by_id(self, project_id: str) -> Project | None:
         """
-        Get a project from the Intel® Geti™ server by project_id.
+        Get a project from the Geti™ server by project_id.
 
         :param project_id: ID of the project to get
         :return: Project object containing the data of the project, if the project is
@@ -698,7 +698,7 @@ class ProjectClient:
         project: Project | None = None,
     ) -> Project | None:
         """
-        Get a project from the Intel® Geti™ server by project_name or project_id, or
+        Get a project from the Geti™ server by project_name or project_id, or
         update a provided Project object with the latest data from the server.
 
         :param project_name: Name of the project to get

--- a/geti_sdk/rest_clients/testing_client.py
+++ b/geti_sdk/rest_clients/testing_client.py
@@ -24,7 +24,7 @@ SUPPORTED_METRICS = ["global", "local"]
 
 class TestingClient:
     """
-    Class to manage testing jobs for a certain Intel® Geti™ project.
+    Class to manage testing jobs for a certain Geti™ project.
     """
 
     def __init__(self, workspace_id: str, project: Project, session: GetiSession):
@@ -78,7 +78,7 @@ class TestingClient:
 
     def get_test_result(self, job: Job) -> TestResult:
         """
-        Retrieve the result of the model testing job from the Intel® Geti™
+        Retrieve the result of the model testing job from the Geti™
         server
 
         :param job: Job instance representing the model testing job

--- a/geti_sdk/rest_clients/training_client.py
+++ b/geti_sdk/rest_clients/training_client.py
@@ -37,7 +37,7 @@ from geti_sdk.utils.job_helpers import get_job_with_timeout, monitor_job, monito
 
 class TrainingClient:
     """
-    Class to manage training jobs for a certain Intel® Geti™ project.
+    Class to manage training jobs for a certain Geti™ project.
     """
 
     def __init__(self, workspace_id: str, project: Project, session: GetiSession):
@@ -51,7 +51,7 @@ class TrainingClient:
 
     def get_status(self) -> ProjectStatus:
         """
-        Get the current status of the project from the Intel® Geti™ server.
+        Get the current status of the project from the Geti™ server.
 
         :return: ProjectStatus object reflecting the current project status
         """
@@ -66,7 +66,7 @@ class TrainingClient:
 
     def get_jobs(self, project_only: bool = True, running_only: bool = False) -> list[Job]:
         """
-        Return a list of all jobs on the Intel® Geti™ server.
+        Return a list of all jobs on the Geti™ server.
 
         If `project_only = True` (the default), only those jobs related to the project
         managed by this TrainingClient will be returned. If set to False, all jobs in
@@ -74,7 +74,7 @@ class TrainingClient:
 
         :param project_only: True to return only those jobs pertaining to the project
             for which the TrainingClient is active. False to return all jobs in the
-            Intel® Geti™ workspace.
+            Geti™ workspace.
         :param running_only: If set to True, only return those jobs that are still
             running. Completed or Scheduled jobs will not be included in that case
         :return: List of Jobs

--- a/geti_sdk/rest_converters/annotation_rest_converter/annotation_rest_converter.py
+++ b/geti_sdk/rest_converters/annotation_rest_converter/annotation_rest_converter.py
@@ -144,7 +144,7 @@ class AnnotationRESTConverter:
     def from_dict(annotation_scene: dict[str, Any]) -> AnnotationScene:
         """
         Create an AnnotationScene object from a dictionary returned by the
-        /annotations REST endpoint in the Intel® Geti™ platform.
+        /annotations REST endpoint in the Geti™ platform.
 
         :param annotation_scene: dictionary representing an AnnotationScene, which
             contains all annotations for a certain media entity

--- a/geti_sdk/rest_converters/configuration_rest_converter.py
+++ b/geti_sdk/rest_converters/configuration_rest_converter.py
@@ -45,7 +45,7 @@ from geti_sdk.utils import deprecate
 )
 class ConfigurationRESTConverter:
     """
-    Class that handles conversion of Intel® Geti™ REST output for configurable parameter
+    Class that handles conversion of Geti™ REST output for configurable parameter
     entities to objects and vice versa.
     """
 
@@ -54,7 +54,7 @@ class ConfigurationRESTConverter:
         """
         Create an EntityIdentifier object from an input dictionary.
 
-        :param input_dict: Dictionary representing an EntityIdentifier in Intel® Geti™
+        :param input_dict: Dictionary representing an EntityIdentifier in Geti™
         :return: EntityIdentifier object corresponding to the data in `input_dict`
         """
         identifier_type = input_dict.get("type")
@@ -74,7 +74,7 @@ class ConfigurationRESTConverter:
     def from_dict(input_dict: dict[str, Any]) -> ConfigurableParameters:
         """
         Create a ConfigurableParameters object holding the configurable parameters
-        for an entity in the Intel® Geti™ platform, from a dictionary returned by the
+        for an entity in the Geti™ platform, from a dictionary returned by the
         /configuration REST endpoints.
 
         :param input_dict: Dictionary containing the configurable parameters
@@ -95,7 +95,7 @@ class ConfigurationRESTConverter:
     ) -> list[ConfigurableParameters]:
         """
         Create a list of configurable parameters from a list of dictionaries received
-        by the Intel® Geti™ /configuration endpoints.
+        by the Geti™ /configuration endpoints.
 
         :param input_list: List of dictionaries to convert
         :return: List of ConfigurableParameters instances
@@ -161,7 +161,7 @@ class ConfigurationRESTConverter:
         """
         Convert a TaskConfiguration, GlobalConfiguration or FullConfiguration into a
         dictionary, removing fields that are None or are only relevant to the
-        Intel® Geti™ UI.
+        Geti™ UI.
 
         :param configuration: TaskConfiguration or GlobalConfiguration to convert
         :param deidentify: True to remove all unique database identifiers, False to
@@ -190,7 +190,7 @@ class ConfigurationRESTConverter:
     ) -> GlobalConfiguration:
         """
         Create a GlobalConfiguration object holding the configurable parameters
-        for all project-wide components in the Intel® Geti™ project, from input from the
+        for all project-wide components in the Geti™ project, from input from the
         /configuration/global REST endpoint.
 
         :param input_: REST response holding the serialized configurable parameters
@@ -207,7 +207,7 @@ class ConfigurationRESTConverter:
     @staticmethod
     def full_configuration_from_rest(input_dict: dict[str, Any]) -> FullConfiguration:
         """
-        Convert a dictionary holding the full configuration for an Intel® Geti™
+        Convert a dictionary holding the full configuration for an Geti™
         project, as returned by the /configuration endpoint, to an object
         representation.
 

--- a/geti_sdk/rest_converters/job_rest_converter.py
+++ b/geti_sdk/rest_converters/job_rest_converter.py
@@ -20,7 +20,7 @@ from geti_sdk.utils import deserialize_dictionary
 
 class JobRESTConverter:
     """
-    Class that handles conversion of Intel® Geti™ REST output for jobs to objects,
+    Class that handles conversion of Geti™ REST output for jobs to objects,
     and vice-versa
     """
 
@@ -29,7 +29,7 @@ class JobRESTConverter:
         """
         Create a Job instance from the input dictionary passed in `job_dict`.
 
-        :param job_dict: Dictionary representing a job on the Intel® Geti™ server, as
+        :param job_dict: Dictionary representing a job on the Geti™ server, as
             returned by the /jobs endpoints
         :return: Job instance, holding the job data contained in job_dict
         """

--- a/geti_sdk/rest_converters/media_rest_converter.py
+++ b/geti_sdk/rest_converters/media_rest_converter.py
@@ -20,7 +20,7 @@ from geti_sdk.utils import deserialize_dictionary
 
 class MediaRESTConverter:
     """
-    Class that handles conversion of Intel® Geti™ REST output for media entities to
+    Class that handles conversion of Geti™ REST output for media entities to
     objects and vice versa.
     """
 
@@ -28,7 +28,7 @@ class MediaRESTConverter:
     def from_dict(input_dict: dict[str, Any], media_type: type[MediaTypeVar]) -> MediaTypeVar:
         """
         Create an instance of type `media_type` representing a media entity on the
-        Intel® Geti™ server from a dictionary returned by the GETi /media REST
+        Geti™ server from a dictionary returned by the GETi /media REST
         endpoints.
 
         :param input_dict: Dictionary representing the media entity

--- a/geti_sdk/rest_converters/model_rest_converter.py
+++ b/geti_sdk/rest_converters/model_rest_converter.py
@@ -21,7 +21,7 @@ from geti_sdk.utils import deserialize_dictionary
 
 class ModelRESTConverter:
     """
-    Class that handles conversion of Intel® Geti™ REST output for media entities to
+    Class that handles conversion of Geti™ REST output for media entities to
     objects and vice versa.
     """
 
@@ -31,7 +31,7 @@ class ModelRESTConverter:
         Convert a dictionary representing a model group to a ModelGroup object.
 
         :param input_dict: Dictionary representing a model group, as returned by the
-            Intel® Geti™ /model_groups REST endpoint
+            Geti™ /model_groups REST endpoint
         :return: ModelGroup object corresponding to the data in `input_dict`
         """
         return deserialize_dictionary(input_dict, output_type=ModelGroup)
@@ -42,7 +42,7 @@ class ModelRESTConverter:
         Convert a dictionary representing a model to a Model object.
 
         :param input_dict: Dictionary representing a model, as returned by the
-            Intel® Geti™ /model_groups/models REST endpoint
+            Geti™ /model_groups/models REST endpoint
         :return: Model object corresponding to the data in `input_dict`
         """
         model_group_id = input_dict.pop("model_group_id", None)
@@ -56,7 +56,7 @@ class ModelRESTConverter:
         Convert a dictionary representing an optimized model to a OptimizedModel object.
 
         :param input_dict: Dictionary representing an optimized model, as returned by
-            the Intel® Geti™ /model_groups/models REST endpoint
+            the Geti™ /model_groups/models REST endpoint
         :return: OptimizedModel object corresponding to the data in `input_dict`
         """
         model_group_id = input_dict.pop("model_group_id", None)

--- a/geti_sdk/rest_converters/prediction_rest_converter/normalized_prediction_rest_converter.py
+++ b/geti_sdk/rest_converters/prediction_rest_converter/normalized_prediction_rest_converter.py
@@ -37,7 +37,7 @@ class NormalizedPredictionRESTConverter(PredictionRESTConverter):
     def normalized_prediction_from_dict(prediction: dict[str, Any], image_width: int, image_height: int) -> Prediction:
         """
         Legacy method that creates an AnnotationScene object from a dictionary
-        returned by the /annotations REST endpoint in Intel® Geti™ versions 1.1 or
+        returned by the /annotations REST endpoint in Geti™ versions 1.1 or
         below
 
         :param prediction: dictionary representing a Prediction, which

--- a/geti_sdk/rest_converters/prediction_rest_converter/prediction_rest_converter.py
+++ b/geti_sdk/rest_converters/prediction_rest_converter/prediction_rest_converter.py
@@ -32,7 +32,7 @@ class PredictionRESTConverter:
     def from_dict(prediction: dict[str, Any]) -> Prediction:
         """
         Create a Prediction object from a dictionary returned by the
-        /predictions REST endpoint in the Intel® Geti™ platform.
+        /predictions REST endpoint in the Geti™ platform.
 
         :param prediction: dictionary representing a Prediction, which
             contains all prediction annotations for a certain media entity

--- a/geti_sdk/rest_converters/project_rest_converter.py
+++ b/geti_sdk/rest_converters/project_rest_converter.py
@@ -22,7 +22,7 @@ from geti_sdk.utils import deserialize_dictionary
 
 class ProjectRESTConverter:
     """
-    Class that handles conversion of Intel® Geti™ REST output for project entities to
+    Class that handles conversion of Geti™ REST output for project entities to
     objects and vice versa.
     """
 
@@ -30,10 +30,10 @@ class ProjectRESTConverter:
     def from_dict(cls, project_input: dict[str, Any]) -> Project:
         """
         Create a Project from a dictionary representing a project, as
-        returned by the /projects endpoint on the Intel® Geti™ platform.
+        returned by the /projects endpoint on the Geti™ platform.
 
         :param project_input: Dictionary representing a project, as returned by the
-            Intel® Geti™ server
+            Geti™ server
         :return: Project object representing the project given in `project_input`
         """
         prepared_project = copy.deepcopy(project_input)

--- a/geti_sdk/rest_converters/status_rest_converter.py
+++ b/geti_sdk/rest_converters/status_rest_converter.py
@@ -20,7 +20,7 @@ from geti_sdk.utils import deserialize_dictionary
 
 class StatusRESTConverter:
     """
-    Class that handles conversion of Intel® Geti™ REST output for status entities to
+    Class that handles conversion of Geti™ REST output for status entities to
     objects
     """
 
@@ -31,7 +31,7 @@ class StatusRESTConverter:
         `project_status_dict`.
 
         :param project_status_dict: Dictionary representing the status of a project on
-            the Intel® Geti™ server
+            the Geti™ server
         :return: ProjectStatus instance, holding the status data contained in
             project_status_dict
         """

--- a/geti_sdk/rest_converters/test_result_rest_converter.py
+++ b/geti_sdk/rest_converters/test_result_rest_converter.py
@@ -20,7 +20,7 @@ from geti_sdk.utils import deserialize_dictionary
 
 class TestResultRESTConverter:
     """
-    Class that handles conversion of Intel® Geti™ REST output for test results to
+    Class that handles conversion of Geti™ REST output for test results to
     objects, and vice-versa
     """
 
@@ -29,7 +29,7 @@ class TestResultRESTConverter:
         """
         Create a TestResult instance from the input dictionary passed in `result_dict`.
 
-        :param result_dict: Dictionary representing a test result on the Intel® Geti™
+        :param result_dict: Dictionary representing a test result on the Geti™
             server, as returned by the /tests endpoints
         :return: TestResult instance, holding the result data contained in result_dict
         """

--- a/geti_sdk/utils/algorithm_helpers.py
+++ b/geti_sdk/utils/algorithm_helpers.py
@@ -66,7 +66,7 @@ def get_default_algorithm_info(
     Return the names of the default algorithms for the tasks in the `project`. The
     returned response is a map of TaskType to the default algorithm name for that task
 
-    :param session: GetiSession to the Intel Geti server
+    :param session: GetiSession to the Geti server
     :param workspace_id: Workspace ID in which the project to retrieve the default
         algorithms for lives.
     :param project: Project to retrieve the default algorithms for

--- a/geti_sdk/utils/job_helpers.py
+++ b/geti_sdk/utils/job_helpers.py
@@ -43,10 +43,10 @@ def restrict(value: float, min: float = 0, max: float = 1) -> float:  # noqa: A0
 
 def get_job_by_id(job_id: str, session: GetiSession, workspace_id: str) -> Job | None:
     """
-    Retrieve Job information from the Intel® Geti™ server.
+    Retrieve Job information from the Geti™ server.
 
     :param job_id: Unique ID of the job to retrieve
-    :param session: GetiSession instance addressing the Intel® Geti™ platform
+    :param session: GetiSession instance addressing the Geti™ platform
     :param workspace_id: ID of the workspace in which the job was created
     :return: Job instance holding the details of the job
     """
@@ -70,11 +70,11 @@ def get_job_with_timeout(
     timeout: int = 15,
 ) -> Job:
     """
-    Retrieve a Job from the Intel® Geti™ server, by it's unique ID. If the job is not
+    Retrieve a Job from the Geti™ server, by it's unique ID. If the job is not
     found within the specified `timeout`, a RuntimeError is raised.
 
     :param job_id: Unique ID of the job to retrieve
-    :param session: GetiSession instance addressing the Intel® Geti™ platform
+    :param session: GetiSession instance addressing the Geti™ platform
     :param workspace_id: ID of the workspace in which the job was created
     :param job_type: String representing the type of job, for instance "training" or
         "testing"
@@ -108,7 +108,7 @@ def get_job_with_timeout(
                 else:
                     raise job_error
         if job is None:
-            raise RuntimeError(f"Unable to find the resulting {job_type} job on the Intel® Geti™ server.")
+            raise RuntimeError(f"Unable to find the resulting {job_type} job on the Geti™ server.")
     return job
 
 
@@ -119,7 +119,7 @@ def monitor_jobs(session: GetiSession, jobs: list[Job], timeout: int = 10000, in
 
     Progress will be reported in 15s intervals
 
-    :param session: GetiSession instance addressing the Intel® Geti™ platform
+    :param session: GetiSession instance addressing the Geti™ platform
     :param jobs: List of jobs to monitor
     :param timeout: Timeout (in seconds) after which to stop the monitoring
     :param interval: Time interval (in seconds) at which the TrainingClient polls
@@ -195,7 +195,7 @@ def monitor_jobs(session: GetiSession, jobs: list[Job], timeout: int = 10000, in
                         if error.status_code == 404:
                             logging.warning(
                                 f"Job with name `{job.name}` and id `{job.id}` was not "
-                                f"found on the Intel Geti instance. Monitoring is skipped "
+                                f"found on the Geti instance. Monitoring is skipped "
                                 f"for this job."
                             )
                         jobs_with_error.append(job)
@@ -256,7 +256,7 @@ def monitor_job(session: GetiSession, job: Job, timeout: int = 10000, interval: 
 
     Progress will be reported in 15s intervals
 
-    :param session: GetiSession instance addressing the Intel® Geti™ platform
+    :param session: GetiSession instance addressing the Geti™ platform
     :param job: Job to monitor
     :param timeout: Timeout (in seconds) after which to stop the monitoring
     :param interval: Time interval (in seconds) at which the TrainingClient polls
@@ -280,7 +280,7 @@ def monitor_job(session: GetiSession, job: Job, timeout: int = 10000, interval: 
         if error.status_code == 404:
             logging.warning(
                 f"Job with name `{job.name}` and id `{job.id}` was not "
-                f"found on the Intel Geti instance. Monitoring is skipped "
+                f"found on the Geti instance. Monitoring is skipped "
                 f"for this job."
             )
     if job.state in completed_states:

--- a/geti_sdk/utils/label_helpers.py
+++ b/geti_sdk/utils/label_helpers.py
@@ -39,7 +39,7 @@ def generate_classification_labels(labels: list[str], multilabel: bool = False) 
     :param multilabel: True to be able to assign multiple labels to one image, False
         otherwise. Defaults to False.
     :return: List of dictionaries containing the label data that can be sent to the
-        Intel® Geti™ project creation endpoint
+        Geti™ project creation endpoint
     """
     label_list: list[dict[str, str]] = []
     if multilabel or len(labels) == 1:

--- a/notebooks/002_create_project_from_dataset.ipynb
+++ b/notebooks/002_create_project_from_dataset.ipynb
@@ -39,7 +39,7 @@
    "source": [
     "## Import from a supported dataset format\n",
     "\n",
-    "The Intel Geti SDK package provides a class `GetiIE` to easily import datasets from one of the formats supported by Geti, including:\n",
+    "The Geti SDK package provides a class `GetiIE` to easily import datasets from one of the formats supported by Geti, including:\n",
     "- Datumaro\n",
     "- COCO\n",
     "- VOC\n",
@@ -141,7 +141,7 @@
     "\n",
     "If your dataset does not comply with one of the supported formats, there are several ways how to go around this.\n",
     "- You can try to convert your dataset to one of the supported formats and come back to the automated approach. This can be done by writing a script that will do the conversion. The drawback of this approach is that you can end up keeping multiple copies of the same dataset.\n",
-    "- You can implement an [AnnotationReader](https://openvinotoolkit.github.io/geti-sdk/geti_sdk.annotation_readers.html#) of your own by following a few implementation examples already present in the Intel Geti SDK package - [DirectoryTreeAnnotationReader](https://github.com/openvinotoolkit/geti-sdk/blob/main/geti_sdk/annotation_readers/directory_tree_annotation_reader.py). It is especially useful if you have an established home-grown annotation format and the data you gather will be kept in this format in the future as well.\n",
+    "- You can implement an [AnnotationReader](https://openvinotoolkit.github.io/geti-sdk/geti_sdk.annotation_readers.html#) of your own by following a few implementation examples already present in the Geti SDK package - [DirectoryTreeAnnotationReader](https://github.com/openvinotoolkit/geti-sdk/blob/main/geti_sdk/annotation_readers/directory_tree_annotation_reader.py). It is especially useful if you have an established home-grown annotation format and the data you gather will be kept in this format in the future as well.\n",
     "- You can create a project from scratch and upload the data and annotations to it, in multiple steps. This is the most straightforward approach, but it requires more interactions with the server.\n",
     "\n",
     "The following example adopts the last approach: it reads the dataset annotations from a `csv` file, then uses `geti-sdk` to create a detection project, upload images and annotations to it.\n",

--- a/notebooks/009_post_inference_hooks.ipynb
+++ b/notebooks/009_post_inference_hooks.ipynb
@@ -128,7 +128,7 @@
     "- If and only if the prediction contains at least one object labelled `dog`:\n",
     "- Send the image to the Geti project, to a dedicated dataset named 'Inferred images'\n",
     "\n",
-    "Basically, this behaviour can be separated into two parts: A **Trigger** and an **Action**. The first part, in which we check if the prediction contains at least one dog, is the Trigger. If the trigger activates, the Action will be carried out: Sending the data to the Intel Geti server. \n",
+    "Basically, this behaviour can be separated into two parts: A **Trigger** and an **Action**. The first part, in which we check if the prediction contains at least one dog, is the Trigger. If the trigger activates, the Action will be carried out: Sending the data to the Geti server. \n",
     "\n",
     "The reasoning here is that if the prediction contains a dog, we want to collect the image in our animal detection project so that we can include it in the next training round. To achieve this, we will use the `LabelTrigger`: It will activate if the prediction contains any objects labelled `dog`. \n",
     "\n",

--- a/notebooks/012_benchmarking_models.ipynb
+++ b/notebooks/012_benchmarking_models.ipynb
@@ -145,7 +145,7 @@
    "id": "fecd6ede-f3f1-4705-8aa0-4eb3ff2b16ed",
    "metadata": {},
    "source": [
-    "## Preparing the Intel® Geti™ project to run the benchmark\n",
+    "## Preparing the Geti™ project to run the benchmark\n",
     "Now that the `Benchmarker` is initialized, we need to make sure that all the algorithms that we'd like to benchmark have a model trained in the project. To do so, the Benchmarker provides a `prepare_benchmark` method that we can call. If we call it, the method will make sure of three things:\n",
     "1. It will check if every algorithm we want to benchmark has a trained model in the project. If not, it will start model training and will wait for it to complete\n",
     "2. It will check if for every trained model that we want to benchmark an optimized model is available in the specified precision levels. If not, it will trigger model optimiziation in the required precision levels and wait for it to complete\n",

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -31,7 +31,7 @@ This directory contains Jupyter notebooks that demonstrate how to use the Geti S
 ## Try the Notebooks
 
 > [!IMPORTANT]
-> All notebooks require access to a running Intel® Geti™ server.
+> All notebooks require access to a running Geti™ server.
 > Make sure your server is accessible and your authentication is properly configured before running the notebooks.
 
 ### Setup the Repository
@@ -53,7 +53,7 @@ This directory contains Jupyter notebooks that demonstrate how to use the Geti S
 
 ### Authentication Setup
 
-Create a `.env` file in the `notebooks` directory with your Intel® Geti™ server details:
+Create a `.env` file in the `notebooks` directory with your Geti™ server details:
 
 #### Option 1: Personal Access Token (Recommended)
 ```shell
@@ -63,7 +63,7 @@ TOKEN=your_personal_access_token
 ```
 
 To obtain a Personal Access Token:
-1. Open Intel® Geti™ in your browser
+1. Open Geti™ in your browser
 2. Click the **User** menu (top right corner)
 3. Select **Personal access token**
 4. Follow the steps to create and copy your token

--- a/notebooks/use_cases/101_simulate_low_light_product_inspection.ipynb
+++ b/notebooks/use_cases/101_simulate_low_light_product_inspection.ipynb
@@ -9,8 +9,8 @@
     "\n",
     "This notebook shows how to systematically simulate a change in lighting conditions\n",
     "(i.e. a shift in data distribution), and the effect such a change has on model\n",
-    "predictions. The notebook is using the Intel® Geti™ SDK to interact with an\n",
-    "Intel® Geti™ server.\n",
+    "predictions. The notebook is using the Geti™ SDK to interact with an\n",
+    "Geti™ server.\n",
     "\n",
     "**Problem description**: For any given project, a data scientist working on it may\n",
     "want to quantify the effect of image distortions on model performance. For example in\n",
@@ -25,14 +25,14 @@
     "still want to detect fabrication defects. How will this affect their anomaly\n",
     "segmentation model? Of course, they will do real-world tests before implementing\n",
     "any changes, but is it possible to simulate such a shift in data distribution in\n",
-    "advance? *With Intel® Geti™, it is*.\n",
+    "advance? *With Geti™, it is*.\n",
     "\n",
     "**Project type**: Anomaly segmentation\n",
     "\n",
     "**Project name**: Transistor anomaly segmentation\n",
     "\n",
     "\n",
-    "### Step 1: Connect to the Intel® Geti™ server"
+    "### Step 1: Connect to the Geti™ server"
    ]
   },
   {

--- a/notebooks/use_cases/102_from_zero_to_hero_9_steps.ipynb
+++ b/notebooks/use_cases/102_from_zero_to_hero_9_steps.ipynb
@@ -6,18 +6,18 @@
    "metadata": {},
    "source": [
     "\n",
-    "# Intel® Geti™ SDK from Zero to Hero in 9 steps\n",
+    "# Geti™ SDK from Zero to Hero in 9 steps\n",
     "\n",
-    "Intel® Geti™ SDK is a Python package designed to interact with an Intel® Geti™ server via the REST API. It provides various functions for managing projects, downloading and uploading data, deploying projects for local inference, configuring projects and models, launching and monitoring training jobs, and media upload and prediction. Clone and install this repo \n",
+    "Geti™ SDK is a Python package designed to interact with an Geti™ server via the REST API. It provides various functions for managing projects, downloading and uploading data, deploying projects for local inference, configuring projects and models, launching and monitoring training jobs, and media upload and prediction. Clone and install this repo \n",
     "https://github.com/openvinotoolkit/geti-sdk\n",
     "\n",
     "| ![image-7.png](https://github.com/openvinotoolkit/geti-sdk/assets/76463150/43b1ded9-5ec2-4e62-a4aa-01bb974302dc) | \n",
     "|:--:| \n",
-    "| *Intel® Geti™ Platform* |\n",
+    "| *Geti™ Platform* |\n",
     "\n",
     "|![image.png](https://github.com/openvinotoolkit/geti-sdk/assets/76463150/933896fb-90d1-4f20-aac0-24dc5e553ffa) | \n",
     "|:--:| \n",
-    "| *What you can do with Intel® Geti™ SDK* |"
+    "| *What you can do with Geti™ SDK* |"
    ]
   },
   {
@@ -25,7 +25,7 @@
    "id": "1090003a",
    "metadata": {},
    "source": [
-    "Before running this notebook, please make sure you have the Intel Geti SDK installed in your local machine. If not, please follow [these instructions](https://github.com/openvinotoolkit/geti-sdk#installation)."
+    "Before running this notebook, please make sure you have the Geti SDK installed in your local machine. If not, please follow [these instructions](https://github.com/openvinotoolkit/geti-sdk#installation)."
    ]
   },
   {
@@ -42,7 +42,7 @@
    "id": "7bae4a28",
    "metadata": {},
    "source": [
-    "In this notebook, we will use the SDK to create a project on the Intel Geti graphics platform, upload videos, download the displays locally, and run the inference by viewing the results on this same notebook."
+    "In this notebook, we will use the SDK to create a project on the Geti graphics platform, upload videos, download the displays locally, and run the inference by viewing the results on this same notebook."
    ]
   },
   {
@@ -50,7 +50,7 @@
    "id": "f97df60a-01e6-4aaa-8013-c7e981485699",
    "metadata": {},
    "source": [
-    "# Step 1: Connect with your Intel® Geti™ Instance\n",
+    "# Step 1: Connect with your Geti™ Instance\n",
     "\n",
     "We will connect to the platform first, using the server details from the .env file. We will also create a ProjectClient for the server. If you have doubts, please take a look of the previous work you need to do before to [connect](https://github.com/openvinotoolkit/geti-sdk#connecting-to-the-intel-geti-platform) the SDK and the platform. "
    ]
@@ -87,7 +87,7 @@
    "source": [
     "# Step 2: Create a project and upload a video for further annotations\n",
     "\n",
-    "We will create a new project from scratch and will upload a video using the SDK for further annotations into the Intel Geti Platform. We will create an object detection project for person, bike and card detection. \n",
+    "We will create a new project from scratch and will upload a video using the SDK for further annotations into the Geti Platform. We will create an object detection project for person, bike and card detection. \n",
     "\n",
     "| ![image-3.png](https://github.com/openvinotoolkit/geti-sdk/assets/76463150/6f338f36-014a-443a-987f-d672a75f908c) | \n",
     "|:--:| \n",
@@ -114,7 +114,7 @@
     "\n",
     "project_client = ProjectClient(session=geti.session, workspace_id=geti.workspace_id)  # setting up the project client\n",
     "\n",
-    "projects = project_client.list_projects()  # listing the projects in the Intel Geti Instance"
+    "projects = project_client.list_projects()  # listing the projects in the Geti Instance"
    ]
   },
   {
@@ -232,11 +232,11 @@
    "metadata": {},
    "source": [
     "# Step 4: Creating annotations\n",
-    "Once you upload new image or video data, you should open the Intel Geti GUI and create annotations for it. The screenshot below shows an example of the annotator page within Geti.\n",
+    "Once you upload new image or video data, you should open the Geti GUI and create annotations for it. The screenshot below shows an example of the annotator page within Geti.\n",
     "\n",
     "| ![image.png](https://github.com/openvinotoolkit/geti-sdk/assets/76463150/d6c95554-5eec-474f-94a2-23ac6782786b) | \n",
     "|:--:| \n",
-    "| *Annotations within the Intel® Geti™ Platform* |\n",
+    "| *Annotations within the Geti™ Platform* |\n",
     "\n",
     "Alternatively, if you have used the default 'person_car_bike' video that we provided, you can run the cell below to upload some pre-defined annotations for the video to the project. This saves you some time in annotating the frames."
    ]
@@ -268,7 +268,7 @@
    "metadata": {},
    "source": [
     "# Step 5: Training the model\n",
-    "Once sufficient annotations have been made, the project is ready for training. Due to the incremental learning mechanism within the Intel Geti platform, training will happen automatically and frequently. Whenever sufficient new annotations have been created, the platform will start a training round. \n",
+    "Once sufficient annotations have been made, the project is ready for training. Due to the incremental learning mechanism within the Geti platform, training will happen automatically and frequently. Whenever sufficient new annotations have been created, the platform will start a training round. \n",
     "\n",
     "In the next part of the notebook we will deploy the model that was trained, so that we can use it locally to generate predictions. However, before doing so we need to make sure that the project has a model trained. The cell below ensures this: It will start training and monitor the training progress if no model is available yet."
    ]
@@ -359,11 +359,11 @@
    "source": [
     "# Step 7: Run the inference and digest new data into the Platform\n",
     "\n",
-    "We will run the inference locally and send some detection frames to the Intel Geti Platform, in order to annotate those and retrain a new model.\n",
+    "We will run the inference locally and send some detection frames to the Geti Platform, in order to annotate those and retrain a new model.\n",
     "\n",
-    "What happens if something new comes in your production system? Different acquisition conditions, lighting, camera, backgrounds. You can connect your production system with Intel Geti Platform in a flexible way through the Intel Geti SDK.\n",
+    "What happens if something new comes in your production system? Different acquisition conditions, lighting, camera, backgrounds. You can connect your production system with Geti Platform in a flexible way through the Geti SDK.\n",
     "\n",
-    "Note: For this use case we will send images back to the Intel Geti Platform when the number of detections per frame will be higher than 1."
+    "Note: For this use case we will send images back to the Geti Platform when the number of detections per frame will be higher than 1."
    ]
   },
   {
@@ -415,7 +415,7 @@
    "source": [
     "## Main function for running the inference with video files or USB camera\n",
     "\n",
-    "This main function create a video player object to manage video files or USB cameras. By default we play the video in 30 FPS, and every single frame will be analyzed by the model. It also runs the inference using the Intel Geti SDK and create a queue of frames to be sent back to the Intel Geti platform.\n",
+    "This main function create a video player object to manage video files or USB cameras. By default we play the video in 30 FPS, and every single frame will be analyzed by the model. It also runs the inference using the Geti SDK and create a queue of frames to be sent back to the Geti platform.\n",
     "\n",
     "Essentially, the code has four main components:\n",
     "\n",
@@ -495,7 +495,7 @@
     "\n",
     "            # ==========================3. Sending images back to the platform======================\n",
     "\n",
-    "            # if the prediction has more than one label send the image back to Intel Geti Platform\n",
+    "            # if the prediction has more than one label send the image back to Geti Platform\n",
     "            if len(prediction.annotations) > 1:\n",
     "                # image = image_client.upload_image(input_image)\n",
     "                uploader.add_data(input_image)\n",
@@ -574,7 +574,7 @@
    "id": "2f34900c",
    "metadata": {},
    "source": [
-    "This example showcases Intel® Geti™ SDK with a video file, but you can use live camera streams or so in a similar manner, just change the source argument in the previous function to make it equal the the camera source number."
+    "This example showcases Geti™ SDK with a video file, but you can use live camera streams or so in a similar manner, just change the source argument in the previous function to make it equal the the camera source number."
    ]
   },
   {
@@ -590,7 +590,7 @@
     "\n",
     "| ![image.png](https://github.com/openvinotoolkit/geti-sdk/assets/76463150/f65c8973-b151-47a7-b291-19bb3c3b8694) | \n",
     "|:--:| \n",
-    "| *Interactive annotation with the Intel® Geti™ Platform* |\n",
+    "| *Interactive annotation with the Geti™ Platform* |\n",
     "\n",
     "Alternatively, if you have used the default 'person_car_bike' video that we provided, you can run the cell below to upload some pre-defined annotations for the video to the project. This saves you some time in annotating the frames."
    ]

--- a/notebooks/use_cases/103_parking_lot_train2deployment.ipynb
+++ b/notebooks/use_cases/103_parking_lot_train2deployment.ipynb
@@ -6,11 +6,11 @@
    "metadata": {},
    "source": [
     "\n",
-    "# Intelligent car counting with Intel® Geti™ SDK from Training to Deployment\n",
+    "# Intelligent car counting with Geti™ SDK from Training to Deployment\n",
     "\n",
-    "## Smart Car Counting for Efficient Urban Management: Harnessing the Power of Intel Geti Platform, Intel Geti SDK, and OpenVINO Integration\n",
+    "## Smart Car Counting for Efficient Urban Management: Harnessing the Power of Geti Platform, Geti SDK, and OpenVINO Integration\n",
     "\n",
-    "In this comprehensive notebook, we will guide developers through the process of creating a smart car counting system for parking lots using the cutting-edge Intel Geti platform, its SDK, and seamless integration with OpenVINO. We will demonstrate how to train models, manipulate training features, and deploy the solution locally, all while reaping the numerous benefits of OpenVINO's accelerated inferencing capabilities.\n",
+    "In this comprehensive notebook, we will guide developers through the process of creating a smart car counting system for parking lots using the cutting-edge Geti platform, its SDK, and seamless integration with OpenVINO. We will demonstrate how to train models, manipulate training features, and deploy the solution locally, all while reaping the numerous benefits of OpenVINO's accelerated inferencing capabilities.\n",
     "\n",
     "| ![image.png](https://github.com/openvinotoolkit/geti-sdk/assets/76463150/5dc1d5a3-0ea3-42f0-831e-53489304d44e) | \n",
     "|:--:| \n",
@@ -18,7 +18,7 @@
     "\n",
     "| ![image-7.png](https://github.com/openvinotoolkit/geti-sdk/assets/76463150/5357bd34-26a7-4f20-b4cb-3b56a9b4ee77) | \n",
     "|:--:| \n",
-    "| *Intel® Geti™ Platform* |"
+    "| *Geti™ Platform* |"
    ]
   },
   {
@@ -26,7 +26,7 @@
    "id": "1090003a",
    "metadata": {},
    "source": [
-    "Before running this notebook, please make sure you have the Intel Geti SDK installed in your local machine. If not, please follow [these instructions](https://github.com/openvinotoolkit/geti-sdk#installation)."
+    "Before running this notebook, please make sure you have the Geti SDK installed in your local machine. If not, please follow [these instructions](https://github.com/openvinotoolkit/geti-sdk#installation)."
    ]
   },
   {
@@ -34,7 +34,7 @@
    "id": "7bae4a28",
    "metadata": {},
    "source": [
-    "In this notebook, we will use the SDK to create a project on the Intel Geti graphics platform, upload videos, download the displays locally, and run the inference by viewing the results on this same notebook."
+    "In this notebook, we will use the SDK to create a project on the Geti graphics platform, upload videos, download the displays locally, and run the inference by viewing the results on this same notebook."
    ]
   },
   {
@@ -62,7 +62,7 @@
    "id": "f97df60a-01e6-4aaa-8013-c7e981485699",
    "metadata": {},
    "source": [
-    "# Step 1: Connect with your Intel® Geti™ Instance\n",
+    "# Step 1: Connect with your Geti™ Instance\n",
     "\n",
     "We will connect to the platform first, using the server details from the .env file. We will also create a ProjectClient for the server. If you have doubts, please take a look of the previous work you need to do before to [connect](https://github.com/openvinotoolkit/geti-sdk#connecting-to-the-intel-geti-platform) the SDK and the platform. "
    ]
@@ -99,7 +99,7 @@
    "source": [
     "# Step 2: Create a project and upload a video for further annotations\n",
     "\n",
-    "We will create a new project from scratch and will upload a video using the SDK for further annotations into the Intel Geti Platform. We will create an object detection project for person, bike and card detection. \n",
+    "We will create a new project from scratch and will upload a video using the SDK for further annotations into the Geti Platform. We will create an object detection project for person, bike and card detection. \n",
     "\n",
     "| ![image.png](https://github.com/openvinotoolkit/geti-sdk/assets/76463150/49dbe60f-4a7b-47dd-a42c-71ad28c93593) | \n",
     "|:--:| \n",
@@ -126,7 +126,7 @@
     "\n",
     "project_client = ProjectClient(session=geti.session, workspace_id=geti.workspace_id)  # setting up the project client\n",
     "\n",
-    "projects = project_client.list_projects()  # listing the projects in the Intel Geti Instance"
+    "projects = project_client.list_projects()  # listing the projects in the Geti Instance"
    ]
   },
   {
@@ -276,15 +276,15 @@
    "metadata": {},
    "source": [
     "# Step 4: Creating annotations\n",
-    "Once you upload new image or video data, you should open the Intel Geti GUI and create annotations for it. The screenshot below shows an example of the annotator page within Geti.\n",
+    "Once you upload new image or video data, you should open the Geti GUI and create annotations for it. The screenshot below shows an example of the annotator page within Geti.\n",
     "\n",
     "| ![image.png](https://github.com/openvinotoolkit/geti-sdk/assets/76463150/51ba8173-11a1-4cc5-8e24-2be0989afdf8) | \n",
     "|:--:| \n",
-    "| *Annotations within the Intel® Geti™ Platform* |\n",
+    "| *Annotations within the Geti™ Platform* |\n",
     "\n",
     "Alternatively, if you have used the default 'parking-lot' image dataset that we provided, you can run the cell below to upload some pre-defined annotations for the images to the project. This saves you some time in annotating the images.\n",
     "\n",
-    "But before to upload the annotations, we need to disable the auto-training option from the Intel Geti server, for avoing auto training when the first  12 annotations have been submitted."
+    "But before to upload the annotations, we need to disable the auto-training option from the Geti server, for avoing auto training when the first  12 annotations have been submitted."
    ]
   },
   {
@@ -331,9 +331,9 @@
    "metadata": {},
    "source": [
     "# Step 5: Training the model\n",
-    "Once sufficient annotations have been made, the project is ready for training. Due to the incremental learning mechanism within the Intel Geti platform, training will happen automatically and frequently. Whenever sufficient new annotations have been created, the platform will start a training round. \n",
+    "Once sufficient annotations have been made, the project is ready for training. Due to the incremental learning mechanism within the Geti platform, training will happen automatically and frequently. Whenever sufficient new annotations have been created, the platform will start a training round. \n",
     "\n",
-    "In the next part of the notebook we will deploy the model that was trained, so that we can use it locally to generate predictions. However, before doing so we need to make sure that the project has a model trained. The cell below trigger the training process for all possible algorithms the Intel Geti Platform supports. Only one model is trained at a time for a project, so it will take some time but you could see the differences between architectures, and make the decision about which architecture is better for your use case\n",
+    "In the next part of the notebook we will deploy the model that was trained, so that we can use it locally to generate predictions. However, before doing so we need to make sure that the project has a model trained. The cell below trigger the training process for all possible algorithms the Geti Platform supports. Only one model is trained at a time for a project, so it will take some time but you could see the differences between architectures, and make the decision about which architecture is better for your use case\n",
     "\n"
    ]
   },
@@ -383,7 +383,7 @@
    "source": [
     "### Optimize/Quantize your models with OpenVINO\n",
     "\n",
-    "OpenVINO helps with the optimization and quantization process, there are multiple options to optimize and quantize the models. On of them is using the Post training Quantization process with POT. For triggering that option on the Intel Geti platform, you can fetch the trained model and then request an optimization job to optimize it with POT. The code in the next cell shows how this is done."
+    "OpenVINO helps with the optimization and quantization process, there are multiple options to optimize and quantize the models. On of them is using the Post training Quantization process with POT. For triggering that option on the Geti platform, you can fetch the trained model and then request an optimization job to optimize it with POT. The code in the next cell shows how this is done."
    ]
   },
   {
@@ -572,11 +572,11 @@
    "source": [
     "# Step 7: Run the inference and ingest new data into the Platform\n",
     "\n",
-    "We will run the inference locally and send some detection frames to the Intel Geti Platform, in order to annotate those and retrain a new model.\n",
+    "We will run the inference locally and send some detection frames to the Geti Platform, in order to annotate those and retrain a new model.\n",
     "\n",
-    "What happens if something new comes in your production system? Different acquisition conditions, lighting, camera, backgrounds. You can connect your production system with Intel Geti Platform in a flexible way through the Intel Geti SDK.\n",
+    "What happens if something new comes in your production system? Different acquisition conditions, lighting, camera, backgrounds. You can connect your production system with Geti Platform in a flexible way through the Geti SDK.\n",
     "\n",
-    "Note: For this use case we will send images back to the Intel Geti Platform when the number of detections per frame will be higher than 1."
+    "Note: For this use case we will send images back to the Geti Platform when the number of detections per frame will be higher than 1."
    ]
   },
   {
@@ -607,7 +607,7 @@
    "source": [
     "## Main function for running the inference with video files or USB camera\n",
     "\n",
-    "This main function create a video player object to manage video files or USB cameras. By default we play the video in 30 FPS, and every single frame will be analyzed by the model. It also runs the inference using the Intel Geti SDK and create a queue of frames to be sent back to the Intel Geti platform.\n",
+    "This main function create a video player object to manage video files or USB cameras. By default we play the video in 30 FPS, and every single frame will be analyzed by the model. It also runs the inference using the Geti SDK and create a queue of frames to be sent back to the Geti platform.\n",
     "\n",
     "Essentially, the code has four main components:\n",
     "\n",
@@ -714,7 +714,7 @@
     "\n",
     "            # ==========================3. Sending images back to the platform======================\n",
     "\n",
-    "            # if the prediction has more than one label send the image back to Intel Geti Platform\n",
+    "            # if the prediction has more than one label send the image back to Geti Platform\n",
     "            if len(prediction.annotations) == 1:\n",
     "                for annotation in prediction.annotations:\n",
     "                    for label in annotation.labels:\n",
@@ -825,7 +825,7 @@
    "id": "2f34900c",
    "metadata": {},
    "source": [
-    "This example showcases Intel® Geti™ SDK with a video file, but you can use live camera streams or so in a similar manner, just change the source argument in the previous function to make it equal the the camera source number."
+    "This example showcases Geti™ SDK with a video file, but you can use live camera streams or so in a similar manner, just change the source argument in the previous function to make it equal the the camera source number."
    ]
   },
   {
@@ -841,7 +841,7 @@
     "\n",
     "| ![image.png](https://github.com/openvinotoolkit/geti-sdk/assets/76463150/e48e98d1-37d6-4989-90b5-49ac106997dc)) | \n",
     "|:--:| \n",
-    "| *Interactive annotation with the Intel® Geti™ Platform* |\n",
+    "| *Interactive annotation with the Geti™ Platform* |\n",
     "\n",
     "Alternatively, if you have used the default 'person_car_bike' video that we provided, you can run the cell below to upload some pre-defined annotations for the video to the project. This saves you some time in annotating the frames."
    ]

--- a/notebooks/use_cases/utils/upload.py
+++ b/notebooks/use_cases/utils/upload.py
@@ -25,7 +25,7 @@ from geti_sdk.rest_clients import ImageClient
 
 class Uploader:
     """
-    Upload images to Intel Geti Platform using threading.
+    Upload images to Geti Platform using threading.
 
     :param num_worker_threads: Number of workers to use for the uploading
     :param image_client: ImageClient instance that will be used to upload the images
@@ -45,7 +45,7 @@ class Uploader:
 
     def upload_image(self, image: np.ndarray | str | os.PathLike):
         """
-        Upload image to the Intel Geti project
+        Upload image to the Geti project
 
         :param image: Image to upload
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "geti-sdk"
-description = "Software Development Kit for the Intel® Geti™ platform"
+description = "Software Development Kit for the Geti™ platform"
 authors = [
     {name = "Intel Corporation"}
 ]

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,7 +1,7 @@
-This directory contains the test suite for the Intel® Geti™ SDK. The tests are grouped
+This directory contains the test suite for the Geti™ SDK. The tests are grouped
 into two categories:
 
-1. **Pre-merge tests** These are executed for every Pull Request to the Intel® Geti™
+1. **Pre-merge tests** These are executed for every Pull Request to the Geti™
    SDK `main` branch. The suite contains both integration and unit tests, the main focus
    being the integration tests. The test code can be found in
    the [pre-merge](pre-merge) folder.
@@ -16,7 +16,7 @@ into two categories:
 The integration tests for the SDK leverage the recording of HTTP requests and responses,
 relying on the VCR.py package. All integration tests are defined in the
 [pre-merge/integration](pre-merge/integration) directory. By default, the tests are run
-in offline mode, meaning that no actual Intel® Geti™ server is needed and no real
+in offline mode, meaning that no actual Geti™ server is needed and no real
 http requests are being made during testing. All requests are intercepted, and a
 previously recorded response is returned. The recorded interactions can be found in
 [fixtures/cassettes](fixtures/cassettes).
@@ -31,9 +31,9 @@ integration testing.
 
 # Nightly test suite
 The nightly tests are defined in the [nightly](nightly) directory. They can only be run in
-`ONLINE` mode, meaning that a live Intel® Geti™ server is required to run against them. The
+`ONLINE` mode, meaning that a live Geti™ server is required to run against them. The
 nightly tests need to be run using a `online.ini` file that contains the host name and
-login details for the Intel® Geti™ server to run the tests against (see section
+login details for the Geti™ server to run the tests against (see section
 [Running the tests](#running-the-tests) below).
 
 # Running the tests
@@ -48,11 +48,11 @@ can be run in `ONLINE` or `RECORD` mode. The simplest way to change modes is to
 define a custom pytest configuration file for each mode, as explained below:
 
 ### Online mode
-If you want to run the test suite against a live Intel® Geti™ server (for example to make sure
-that the SDK data models are still up to date with the Intel® Geti™ REST contracts), the tests
+If you want to run the test suite against a live Geti™ server (for example to make sure
+that the SDK data models are still up to date with the Geti™ REST contracts), the tests
 can be executed in `ONLINE` mode. To do so, define a file `online.ini` in the `tests`
 directory. This file should have similar content to the existing `offline.ini`, but
-with the Intel® Geti™ server hostname and login details set appropriately:
+with the Geti™ server hostname and login details set appropriately:
 
 > ```shell
 > [pytest]
@@ -81,10 +81,10 @@ Once you created the custom `online.ini` or `record.ini` configurations, you can
 the tests using `pytest -c online.ini ./pre-merge`. This will execute the tests in
 online mode.
 
-### Tests Intel® Geti™ SDK against the previous version of Intel® Geti™ server.
-You can run the test suite against a legacy version of Intel® Geti™ server.
+### Tests Geti™ SDK against the previous version of Geti™ server.
+You can run the test suite against a legacy version of Geti™ server.
 - In `ONLINE` mode  Simply assign the `GETI_HOST` variable with the legacy server’s address.
 - In `OFFLINE` and `RECORD` modes one can set the `GETI_PLATFORM_VERSION` variable to `LEGACY`
 within `offline.ini` or `record.ini` correspondingly, thus utilizing the pre-recorded cassettes from the prior server release for testing.
 
-> **_NOTE:_**  Currently,  Intel® Geti™ 1.8 is considered as the legacy release.
+> **_NOTE:_**  Currently,  Geti™ 1.8 is considered as the legacy release.

--- a/tests/helpers/datumaro_annotation_reader/datumaro_annotation_reader.py
+++ b/tests/helpers/datumaro_annotation_reader/datumaro_annotation_reader.py
@@ -172,7 +172,7 @@ class DatumAnnotationReader(AnnotationReader):
             (e.g. width, height) about the media item to upload the annotation for
         :param preserve_shape_for_global_labels: False to convert shapes for global
             tasks to full rectangles (required for classification like tasks in
-            Intel® Geti™ projects), True to preserve such shapes. This parameter
+            Geti™ projects), True to preserve such shapes. This parameter
             should be:
 
              - False when uploading annotations to a single task project
@@ -194,7 +194,7 @@ class DatumAnnotationReader(AnnotationReader):
             try:
                 label_name = self.datum_label_map[annotation.label]
             except KeyError:
-                # Label is not in the Intel® Geti™ project labels, move on to next
+                # Label is not in the Geti™ project labels, move on to next
                 # annotation for this dataset item.
                 continue
 

--- a/tests/helpers/datumaro_annotation_reader/datumaro_dataset.py
+++ b/tests/helpers/datumaro_annotation_reader/datumaro_dataset.py
@@ -40,7 +40,7 @@ class DatumaroDataset:
     """
     Wrapper for interacting with the datumaro dataset, contains some example
     functions for dataset operations that can be carried out prior to importing the
-    dataset into an Intel® Geti™ project.
+    dataset into an Geti™ project.
     """
 
     def __init__(self, dataset_format: str, dataset_path: str):
@@ -61,7 +61,7 @@ class DatumaroDataset:
 
     def prepare_dataset(self, task_type: TaskType, previous_task_type: TaskType | None = None) -> Dataset:
         """
-        Prepare the dataset for uploading to Intel Geti.
+        Prepare the dataset for uploading to Geti.
 
         :param task_type: TaskType to prepare the dataset for
         :param previous_task_type: Optional type of the (trainable) task preceding

--- a/tests/helpers/project_helpers.py
+++ b/tests/helpers/project_helpers.py
@@ -48,7 +48,7 @@ def get_or_create_annotated_project_for_test_class(
     :param annotation_requirements_first_training: The required amount of annotations for first training.
     :param keypoint_structure: The structure of the keypoints to be used for the project,
         represented as a graph of nodes and edges.
-    :return: Project instance corresponding to the project on the Intel® Geti™ server
+    :return: Project instance corresponding to the project on the Geti™ server
     """
     project_exists = project_service.has_project
     labels = [reader.get_all_label_names() for reader in annotation_readers]

--- a/tests/pre-merge/unit/test_platform_version.py
+++ b/tests/pre-merge/unit/test_platform_version.py
@@ -32,7 +32,7 @@ class TestGetiVersion:
     def test_comparison(self) -> None:
         """
         Test parsing the version from a version string, for different release versions
-        of the Intel Geti platform. Also test comparisons between versions
+        of the Geti platform. Also test comparisons between versions
         """
         assert GETI_10_VERSION < GETI_11_VERSION
         assert GETI_11_VERSION >= GETI_10_VERSION


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/geti-sdk/blob/main/CONTRIBUTING.md -->

### Summary

This PR changes the Geti brand in scope of https://github.com/open-edge-platform/geti/issues/1189

### How to test

See if there are any remaining Intel Geti names.

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have tested my changes manually.​
- [ ] I have added tests to cover my changes.​

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/geti-sdk/blob/main/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
# http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions
# and limitations under the License.
```
