### PR TITLE
feat(ci): adding Semgrep in the CI

### DIFF
--- a/.github/workflows/build-package-pypi.yaml
+++ b/.github/workflows/build-package-pypi.yaml
@@ -29,6 +29,7 @@ jobs:
         uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4 # v6.7.0
         with:
           version: "0.7.13"
+          enable-cache: false # do not consume caches in release builds to avoid cache poisoning
 
       - name: Prepare venv and install Python dependencies
         run: |

--- a/.github/workflows/build-package-test-pypi.yaml
+++ b/.github/workflows/build-package-test-pypi.yaml
@@ -29,6 +29,7 @@ jobs:
         uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4 # v6.7.0
         with:
           version: "0.7.13"
+          enable-cache: false # do not consume caches in release builds to avoid cache poisoning
 
       - name: Prepare venv and install Python dependencies
         run: |

--- a/.github/workflows/pre-merge-tests.yml
+++ b/.github/workflows/pre-merge-tests.yml
@@ -107,8 +107,8 @@ jobs:
         uses: open-edge-platform/geti-ci/actions/zizmor@c2bb2697178bb2e50014420aef2351a45749b925
         with:
           scan-scope: "changed"
-          severity-level: "MEDIUM"
-          confidence-level: "HIGH"
+          severity-level: "LOW"
+          confidence-level: "LOW"
           fail-on-findings: true
 
   bandit-scan-pr:

--- a/.github/workflows/pre-merge-tests.yml
+++ b/.github/workflows/pre-merge-tests.yml
@@ -99,6 +99,10 @@ jobs:
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
         with:
           egress-policy: audit
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Run Zizmor scan
         uses: open-edge-platform/geti-ci/actions/zizmor@c2bb2697178bb2e50014420aef2351a45749b925
         with:
@@ -116,6 +120,10 @@ jobs:
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
         with:
           egress-policy: audit
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Run Bandit scan
         uses: open-edge-platform/geti-ci/actions/bandit@c2bb2697178bb2e50014420aef2351a45749b925
         with:

--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -23,6 +23,10 @@ jobs:
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
         with:
           egress-policy: audit
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Run Zizmor scan
         uses: open-edge-platform/geti-ci/actions/zizmor@c2bb2697178bb2e50014420aef2351a45749b925
         with:
@@ -41,6 +45,10 @@ jobs:
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
         with:
           egress-policy: audit
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Run Bandit scan
         uses: open-edge-platform/geti-ci/actions/bandit@c2bb2697178bb2e50014420aef2351a45749b925
         with:
@@ -60,6 +68,10 @@ jobs:
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
         with:
           egress-policy: audit
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Run Trivy scan
         id: trivy
         uses: open-edge-platform/geti-ci/actions/trivy@c2bb2697178bb2e50014420aef2351a45749b925
@@ -71,3 +83,25 @@ jobs:
           format: "sarif"
           timeout: "15m"
           ignore_unfixed: "false"
+
+  semgrep-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # Needed to upload the results to code-scanning dashboard
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+      - name: Checkout code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+      - name: Run Semgrep scan
+        id: semgrep
+        uses: open-edge-platform/geti-ci/actions/semgrep@353d464dd966cc07ce9c5109e70c12c17fb60942
+        with:
+          scan-scope: "all"
+          severity: "LOW"
+          fail-on-findings: false # reports only

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,7 @@ Pull Request, Feature Request or general comment/issue that you found. For featu
 requests and issues, please feel free to create a GitHub Issue in this repository.
 
 # Development and pull requests
+
 To set up your development environment, please follow the steps below:
 
 1. Clone the repository or a fork (for external contributors):
@@ -14,6 +15,7 @@ To set up your development environment, please follow the steps below:
 3. Install uv following the official [uv documentation](https://docs.astral.sh/uv/getting-started/installation/).
 
 4. Set up the development environment with all dependencies:
+
    ```bash
    uv sync --all-extras
    ```
@@ -32,5 +34,63 @@ To set up your development environment, please follow the steps below:
 You should now be ready to make changes, run the SDK integration tests and create a Pull Request!
 
 ## Testing your code
+
 More details about the tests can be found in the [readme](tests/README.md) for the test suite.
 If your changes require updating the tests or the test data, please refer to that document.
+
+## Security
+
+To ensure our codebase remains secure, we leverage GitHub Actions for continuous security scanning (on PR and periodically) with the following tools:
+
+- [CodeQL](https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql): static analysis tool to check Python code and GitHub Actions workflows
+- [Semgrep](https://github.com/semgrep/semgrep): static analysis tool to check Python code; ML-specific Semgrep rules developed by [Trail of Bits](https://github.com/trailofbits/semgrep-rules?tab=readme-ov-file#python) are used
+- [Bandit](https://github.com/PyCQA/bandit): Static analysis tool to check Python code
+- [Zizmor](https://github.com/woodruffw/zizmor): Static analysis tool to check GitHub Actions workflows
+- [Trivy](https://github.com/aquasecurity/trivy): Check misconfigurations and detect security issues in dependencies
+
+| Tool    | Pre-commit | PR-checks | Periodic |
+| ------- | ---------- | --------- | -------- |
+| CodeQL  |            | ✅        | ✅       |
+| Semgrep |            |           | ✅       |
+| Bandit  |            | ✅        | ✅       |
+| Zizmor  |            | ✅        | ✅       |
+| Trivy   |            |           | ✅       |
+
+<details>
+<summary>Suppressing False Positives</summary>
+
+If necessary, to suppress _false_ positives, add inline comment with specific syntax.
+Please also add a comment explaining _why_ you decided to disable a rule or provide a risk-acceptance reason.
+
+### Bandit
+
+Findings can be ignored inline with `# nosec BXXX` comments.
+
+```python
+import subprocess # nosec B404 # this is actually fine
+```
+
+[Details](https://bandit.readthedocs.io/en/latest/config.html#exclusions) in Bandit docs.
+
+### Zizmor
+
+Findings can be ignored inline with `# zizmor: ignore[rulename]` comments.
+
+```yaml
+uses: actions/checkout@v3 # zizmor: ignore[artipacked] this is actually fine
+```
+
+[Details](https://woodruffw.github.io/zizmor/usage/#with-comments) in Zizmor docs.
+
+### Semgrep
+
+Findings can be ignored inline with `# nosemgrep: rule-id` comments.
+
+```python
+    # nosemgrep: python.lang.security.audit.dangerous-system-call.dangerous-system-call # this is actually fine
+    r = os.system(' '.join(command))
+```
+
+[Details](https://semgrep.dev/docs/ignoring-files-folders-code) in Semgrep docs.
+
+</details>


### PR DESCRIPTION
<!-- Contributing guide: https://github.com/open-edge-platform/geti-sdk/blob/main/CONTRIBUTING.md -->

### Summary

This PR adds a Semgrep scan in the CI (`push` trigger). Checks on the `pull_request` trigger will be enabled in a separate PR.

In addition:
- Updated contribution guidelines with application security-related information
- Fixed several Zizmor findings

### How to test
<!-- Describe the testing procedure for reviewers, if changes are
not fully covered by unit tests or manual testing can be complicated. -->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [x] I have tested my changes manually.​
- [ ] I have added tests to cover my changes.​

### License

- [x] I submit _my code changes_ under the same [Apache License](https://github.com/open-edge-platform/geti-sdk/blob/main/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below).

```python
# Copyright (C) 2025 Intel Corporation
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
# http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing,
# software distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions
# and limitations under the License.
```
